### PR TITLE
Add support for batch processing of users and roles add and remove to existing apis

### DIFF
--- a/auth_service.js
+++ b/auth_service.js
@@ -104,11 +104,11 @@ deprecatedRoutes.addDeprecatedRoutes(AuthWebService, config);
 if (process.env.NODE_DEPLOY_TARGET === "production") {
   AuthWebService.listen(config.httpsOptions.port);
   console.log("Running in production mode behind an Nginx proxy, Listening on http port %d", config.httpsOptions.port);
-  });
 } else {
   config.httpsOptions.key = FileSystem.readFileSync(config.httpsOptions.key);
   config.httpsOptions.cert = FileSystem.readFileSync(config.httpsOptions.cert);
 
   https.createServer(config.httpsOptions, AuthWebService).listen(config.httpsOptions.port, function() {
     console.log("Listening on https port %d", config.httpsOptions.port);
+  });
 }

--- a/auth_service.js
+++ b/auth_service.js
@@ -101,14 +101,14 @@ deprecatedRoutes.addDeprecatedRoutes(AuthWebService, config);
  * and then ask https to turn on the webservice
  */
 
-if (config.httpsOptions.protocol === "https://") {
+if (process.env.NODE_DEPLOY_TARGET === "production") {
+  AuthWebService.listen(config.httpsOptions.port);
+  console.log("Running in production mode behind an Nginx proxy, Listening on http port %d", config.httpsOptions.port);
+  });
+} else {
   config.httpsOptions.key = FileSystem.readFileSync(config.httpsOptions.key);
   config.httpsOptions.cert = FileSystem.readFileSync(config.httpsOptions.cert);
 
   https.createServer(config.httpsOptions, AuthWebService).listen(config.httpsOptions.port, function() {
-    console.log("Listening on port %d", config.httpsOptions.port);
-  });
-} else {
-  AuthWebService.listen(config.httpsOptions.port);
-  console.log("Listening on port %d", config.httpsOptions.port);
+    console.log("Listening on https port %d", config.httpsOptions.port);
 }

--- a/auth_service.js
+++ b/auth_service.js
@@ -37,7 +37,7 @@ var corsOptions = {
     } else if (origin.search(/^https?:\/\/.*\.lingsync.org$/) > -1 || origin.search(/^https?:\/\/.*\.phophlo.ca$/) > -1 || origin.search(/^https?:\/\/localhost:[0-9]*$/) > -1 || origin.search(/^chrome-extension:\/\/[^\/]*$/) > -1) {
       originIsWhitelisted = true;
     }
-    console.log(new Date() + " Responding with CORS options for " + origin + " accept as whitelisted is: " + originIsWhitelisted);
+    // console.log(new Date() + " Responding with CORS options for " + origin + " accept as whitelisted is: " + originIsWhitelisted);
     callback(null, originIsWhitelisted);
   }
 };

--- a/lib/About.js
+++ b/lib/About.js
@@ -147,6 +147,30 @@ module.exports = function FieldDB(args) {
 				});
 			}
 		};
+    
+    var betatesters = function(doc) {
+      if (!doc.roles || doc.roles.length === 0) {
+        return;
+      }
+      var username = doc._id.replace(/org.couchdb.user:/, "");
+      if (username.indexOf("test") > -1 || username.indexOf("anonymous") > -1 || username.indexOf("acra") > -1) {
+        emit(username, doc.roles);
+      } else {
+        // this is not a beta tester
+      }
+    };
+    var normalusers = function(doc) {
+      if (!doc.roles || doc.roles.length === 0) {
+        return;
+      }
+      var username = doc._id.replace(/org.couchdb.user:/, "");
+      if (username.indexOf("test") > -1 || username.indexOf("anonymous") > -1 || username.indexOf("acra") > -1) {
+        // this is a beta tester
+      } else {
+        emit(username, doc.roles);
+      }
+    };
+
 		var createUsersViewInFielddbUsersDB = function(err, body) {
 			if (err) {
 				console.log(err);

--- a/lib/corpus.js
+++ b/lib/corpus.js
@@ -420,7 +420,8 @@ var isRequestingUserAnAdminOnCorpus = function(req, requestingUser, dbConn, done
                   status: 401,
                   error: "User " + requestingUser + " found but didnt have permission on " + dbConn.pouchname
                 }, null, {
-                  info: "User does not have permission to perform this action."
+                  info: "User does not have permission to perform this action.",
+                  message: "You don't not have permission to perform this action."
                 });
               } else {
                 return done(null, requestingUser, null);

--- a/lib/corpusmanagement.js
+++ b/lib/corpusmanagement.js
@@ -579,6 +579,7 @@ module.exports.changeUsersPassword = function(dbConnection, user, newpassword,
           };
         }
         if (err !== null || !doc.ok) {
+          err.status = err.status || 500;
           console.log(new Date() + " Here are the errors " + util.inspect(err) + " \n Here is the doc we get back " + util.inspect(doc));
           if (typeof errorcallback == "function") {
             errorcallback(err);

--- a/lib/corpusmanagement.js
+++ b/lib/corpusmanagement.js
@@ -126,17 +126,28 @@ module.exports.createDbaddUser = function(dbConnection, user, successcallback, e
     } // end successful user creation
   });
 };
-var addRoleToUser = function(dbConnection, username, roles, successcallback, errorcallback) {
-  console.log(new Date() + " In addRoleToUser " + util.inspect(roles) + " to " + username + " on " + util.inspect(dbConnection));
+var addRoleToUser = function(dbConnection, userPermission, successcallback, errorcallback) {
+  console.log(new Date() + " In addRoleToUser " + util.inspect(userPermission.add) + " to " + userPermission.username + " on " + util.inspect(dbConnection));
+
+
   var c = new cradle.Connection();
+
+  if (!userPermission.add) {
+    userPermission.add = [];
+  }
+
+  if (!userPermission.remove) {
+    userPermission.remove = [];
+  }
 
   var usersdb = c.database("_users", function() {
     console.log(new Date() + " In the callback of opening the users database.");
   });
 
-  var userid = 'org.couchdb.user:' + username;
+  var userid = 'org.couchdb.user:' + userPermission.username;
   usersdb.get(userid, function(err, doc) {
     if (err !== null || !doc._id) {
+      err.status = err.status || 404;
       console.log(new Date() + " Here are the errors " + util.inspect(err) + " \n Here is the doc we get back " + util.inspect(doc));
       if (typeof errorcallback == "function") {
         return errorcallback(err, null, {
@@ -146,35 +157,86 @@ var addRoleToUser = function(dbConnection, username, roles, successcallback, err
       return;
     }
     var userold = doc;
-    console.log(new Date() + " These are the users's roles before adding a role." + util.inspect(userold.roles));
+    console.log(new Date() + " These are the users's roles before adding/removing roles." + util.inspect(userold.roles));
 
-    for (var r in roles) {
-      userold.roles.push(roles[r]);
+    var originalRolesForThisCorpus = userold.roles.map(function(role) {
+      if (role.indexOf(dbConnection.pouchname + "_") > -1) {
+        return role.replace(dbConnection.pouchname + "_", "");
+      }
+      return ""
+    }).join(" ").trim();
+    if (originalRolesForThisCorpus) {
+      originalRolesForThisCorpus = originalRolesForThisCorpus.split(" ");
+    } else {
+      originalRolesForThisCorpus = [];
     }
-    var uniqueroles = _.unique(userold.roles);
-    userold.roles = uniqueroles;
+    userold.roles = _.unique(userold.roles.concat(userPermission.add));
+
+    if (userPermission.remove[0] === dbConnection.pouchname + "_all") {
+      console.log(new Date() + " removing all and any access to this corpus from " + userPermission.username);
+      for (var roleIndex = userold.roles.length - 1; roleIndex >= 0; roleIndex--) {
+        var corpusid = userold.roles[roleIndex].substring(0, userold.roles[roleIndex].lastIndexOf("_"));
+        if (corpusid === dbConnection.pouchname) {
+          userold.roles.splice(roleIndex, 1);
+        }
+      }
+    } else {
+      userPermission.remove.map(function(role) {
+        var roleIsPresent = userold.roles.indexOf(role);
+        if (roleIsPresent > -1) {
+          userold.roles.splice(roleIsPresent, 1);
+        }
+      });
+    }
+
+    var resultingRolesForThisCorpus = userold.roles.map(function(role) {
+      if (role.indexOf(dbConnection.pouchname + "_") > -1) {
+        return role.replace(dbConnection.pouchname + "_", "");
+      }
+      return ""
+    }).join(" ").trim();
+    if (resultingRolesForThisCorpus) {
+      resultingRolesForThisCorpus = resultingRolesForThisCorpus.split(" ");
+    } else {
+      resultingRolesForThisCorpus = [];
+    }
+    // if (resultingRolesForThisCorpus.length === 0) {
+    //   resultingRolesForThisCorpus = ["none"];
+    // }
+    console.log(new Date() + " These are the users's roles after adding/removing roles." + util.inspect(userold.roles));
+
+    userPermission.before = originalRolesForThisCorpus;
+    userPermission.after = resultingRolesForThisCorpus;
+
+    // return errorcallback({
+    //   error: "todo",
+    //   status: 412
+    // }, userPermission, {
+    //   message: "TODO. save userroles "
+    // });
 
     usersdb.save(userold, function(err, doc) {
       if (doc == undefined) {
         doc = {
-          error: err
+          error: err,
+          status: 500
         };
       }
       if (err != null || !doc.ok) {
         console.log(new Date() + " Here are the errors " + util.inspect(err) + " \n Here is the doc we get back " + util.inspect(doc));
         if (typeof errorcallback == "function") {
-          return errorcallback(err, null, {
-            message: "Problem adding role to user."
+          err.status = err.status || 500;
+          return errorcallback(err, userPermission, {
+            message: "There was a problem setting to " + resultingRolesForThisCorpus.join(", ") + " for user " + userPermission.username + ". Please notify us of this error."
           });
         }
       } else {
-        console.log(new Date() + " role " + roles + " created to the CouchDB user " + username + " on: " + util.inspect(dbConnection));
+        console.log(new Date() + " role " + userPermission.add + " created to the CouchDB user " + userPermission.username + " on: " + util.inspect(dbConnection));
         if (typeof successcallback == "function") {
-          return successcallback(null, {
-            roles: roles
-          }, {
-            message: "User role added."
-          });
+          return successcallback(null,
+            userPermission, {
+              message: "User now has " + resultingRolesForThisCorpus.join(", ") + " access to " + dbConnection.pouchname
+            });
         }
       }
     });
@@ -184,6 +246,7 @@ var addRoleToUser = function(dbConnection, username, roles, successcallback, err
 
 };
 module.exports.addRoleToUser = addRoleToUser;
+
 
 /*
  * This function creates a new corpus database
@@ -239,12 +302,15 @@ var createDBforCorpus = function(dbConnection, user, success, error) {
          *
          * References: http://127.0.0.1:5984/john7corpus/_security
          */
-        addRoleToUser(dbConnection, user.username, [
-          dbConnection.pouchname + "_" + admin,
-          dbConnection.pouchname + "_" + contributor,
-          dbConnection.pouchname + "_" + collaborator,
-          dbConnection.pouchname + "_" + commenter
-        ]);
+        addRoleToUser(dbConnection, {
+          username: user.username,
+          add: [
+            dbConnection.pouchname + "_" + admin,
+            dbConnection.pouchname + "_" + contributor,
+            dbConnection.pouchname + "_" + collaborator,
+            dbConnection.pouchname + "_" + commenter
+          ]
+        });
 
         var securityParamsforNewDB = {
           "admins": {

--- a/lib/corpusmanagement.js
+++ b/lib/corpusmanagement.js
@@ -227,9 +227,12 @@ var addRoleToUser = function(dbConnection, userPermission, successcallback, erro
       if (err != null || !doc.ok) {
         console.log(new Date() + " Here are the errors " + util.inspect(err) + " \n Here is the doc we get back " + util.inspect(doc));
         if (typeof errorcallback == "function") {
+          if (err.error === "conflict") {
+            err.status = 409;
+          }
           err.status = err.status || 500;
           userPermission.status = err.status;
-          userPermission.message = "There was a problem setting to " + resultingRolesForThisCorpus.join(", ") + " for user " + userPermission.username + ". Please notify us of this error.";
+          userPermission.message = "There was a problem giving " + resultingRolesForThisCorpus.join(", ") + " access to user " + userPermission.username + ". Please notify us of this error.";
           return errorcallback(err, userPermission, {
             message: userPermission.message
           });

--- a/lib/corpusmanagement.js
+++ b/lib/corpusmanagement.js
@@ -150,8 +150,10 @@ var addRoleToUser = function(dbConnection, userPermission, successcallback, erro
       err.status = err.status || 404;
       console.log(new Date() + " Here are the errors " + util.inspect(err) + " \n Here is the doc we get back " + util.inspect(doc));
       if (typeof errorcallback == "function") {
-        return errorcallback(err, null, {
-          message: "User not found."
+        userPermission.status = err.status;
+        userPermission.message = "User not found.";
+        return errorcallback(err, userPermission, {
+          message: userPermission.message
         });
       }
       return;
@@ -226,16 +228,20 @@ var addRoleToUser = function(dbConnection, userPermission, successcallback, erro
         console.log(new Date() + " Here are the errors " + util.inspect(err) + " \n Here is the doc we get back " + util.inspect(doc));
         if (typeof errorcallback == "function") {
           err.status = err.status || 500;
+          userPermission.status = err.status;
+          userPermission.message = "There was a problem setting to " + resultingRolesForThisCorpus.join(", ") + " for user " + userPermission.username + ". Please notify us of this error.";
           return errorcallback(err, userPermission, {
-            message: "There was a problem setting to " + resultingRolesForThisCorpus.join(", ") + " for user " + userPermission.username + ". Please notify us of this error."
+            message: userPermission.message
           });
         }
       } else {
         console.log(new Date() + " role " + userPermission.add + " created to the CouchDB user " + userPermission.username + " on: " + util.inspect(dbConnection));
         if (typeof successcallback == "function") {
+          userPermission.status = 200;
+          userPermission.message = "User now has " + resultingRolesForThisCorpus.join(", ") + " access to " + dbConnection.pouchname;
           return successcallback(null,
             userPermission, {
-              message: "User now has " + resultingRolesForThisCorpus.join(", ") + " access to " + dbConnection.pouchname
+              message: userPermission.message
             });
         }
       }

--- a/lib/corpusmanagement.js
+++ b/lib/corpusmanagement.js
@@ -172,7 +172,7 @@ var addRoleToUser = function(dbConnection, userPermission, successcallback, erro
     } else {
       originalRolesForThisCorpus = [];
     }
-    userold.roles = _.unique(userold.roles.concat(userPermission.add));
+    userold.roles = _.unique(userPermission.add.concat(userold.roles));
 
     if (userPermission.remove[0] === dbConnection.pouchname + "_all") {
       console.log(new Date() + " removing all and any access to this corpus from " + userPermission.username);

--- a/lib/userauthentication.js
+++ b/lib/userauthentication.js
@@ -28,13 +28,13 @@ var commenter = "commenter";
 var dontCreateDBsForLearnXUsersBecauseThereAreTooManyOfThem = true;
 
 
-var authServerVersion = require("package").version;
+var authServerVersion = require("./../package.json").version;
 
 //Only create users on the same server.
 var parsed = url.parse("http://localhost:5984");
 var couchConnectUrl = parsed.protocol + "//" + couch_keys.username + ":" + couch_keys.password + "@" + parsed.host;
 
-console.log(new Date() + " Loading the User Authentication Module");
+console.log(new Date() + " Loading the User Authentication Module v" + authServerVersion);
 var nano = require('nano')(couchConnectUrl);
 
 //Send email see docs https://github.com/andris9/Nodemailer
@@ -1034,7 +1034,7 @@ module.exports.fetchCorpusPermissions = function(req, done) {
    */
   var usersdb = nanoforpermissions.db.use("_users");
   var whichUserGroup = "normalusers";
-  if (doc.username.indexOf("test") > -1 || doc.username.indexOf("anonymous") > -1) {
+  if (requestingUser.indexOf("test") > -1 || requestingUser.indexOf("anonymous") > -1) {
     whichUserGroup = "betatesters";
   }
   usersdb.view("users", whichUserGroup, function(error, body) {
@@ -1065,63 +1065,114 @@ module.exports.fetchCorpusPermissions = function(req, done) {
         } else {
           var usermasks = body.rows;
 
-          var rolesAndUsers = {};
+
+          /*
+           Convert the array into a hash to avoid n*m behavior (instead we have n+m+h)
+           */
+          var usershash = {},
+            userIndex,
+            key,
+            currentUsername,
+            userIsOnTeam,
+            thisUsersMask,
+            rolesAndUsers = {},
+            requestingUserIsAMemberOfCorpusTeam = false,
+            roles,
+            roleIndex,
+            roleType;
+
           rolesAndUsers.notonteam = [];
           rolesAndUsers.allusers = [];
 
-          userroles.forEach(function(doc) {
-            var currentUsername = doc.key;
-            //console.log(new Date() + " Looking at " + currentUsername);
-            var userIsOnTeam = false;
+          // Put the user roles in
+          for (userIndex = userroles.length - 1; userIndex >= 0; userIndex--) {
+            if (!userroles[userIndex].key || !userroles[userIndex].value) {
+              continue;
+            }
+            key = userroles[userIndex].key;
+            usershash[key] = usershash[key] || {};
+            usershash[key].roles = userroles[userIndex].value;
+          };
 
-            /* Get the mask for this user */
-            var thisUsersMask = {};
-            usermasks.forEach(function(usermask) {
-              if (usermask.key == currentUsername) {
-                thisUsersMask = usermask.value;
-                thisUsersMask.gravatar = md5(thisUsersMask.gravatar_email);
-                delete thisUsersMask.gravatar_email;
-                rolesAndUsers.allusers.push(usermask.value);
-              }
+          // Put the gravatars in
+          for (userIndex = usermasks.length - 1; userIndex >= 0; userIndex--) {
+            if (!usermasks[3].value || !usermasks[3].value.username) {
+              continue;
+            }
+            key = usermasks[3].value.username;
+            // console.log(key, usershash[key]);
+            usershash[key] = usershash[key] || {};
+            usershash[key].username = usermasks[userIndex].value.username;
+            usershash[key].gravatar = usermasks[userIndex].value.gravatar;
+            usershash[key].gravatar_email = usermasks[userIndex].value.gravatar_email;
+          }
+
+          // Put the users into the list of roles and users
+          for (currentUsername in usershash) {
+            if (!usershash.hasOwnProperty(currentUsername) || !currentUsername) {
+              continue;
+            }
+            // console.log(new Date() + " Looking at " + currentUsername);
+            userIsOnTeam = false;
+            thisUsersMask = usershash[currentUsername];
+            if (!thisUsersMask.gravatar && thisUsersMask.gravatar_email) {
+              // thisUsersMask.gravatar = md5(thisUsersMask.gravatar_email);
+            }
+
+            // Add this user to the typeahead
+            rolesAndUsers.allusers.push({
+              username: currentUsername,
+              gravatar: thisUsersMask.gravatar
             });
 
-            /* Go through all the user's roles */
-            var roles = doc.value;
-            roles.forEach(function(role) {
+            // Find out if this user is a member of the team
+            roles = thisUsersMask.roles;
+            if (!roles) {
+              console.log(new Date() + " this is odd, " + currentUsername + " doesnt have any roles defined");
+              roles = [];
+            }
+            for (roleIndex = roles.length - 1; roleIndex >= 0; roleIndex--) {
 
-              /* Check to see if this role is for this corpus */
-              if (role.indexOf(pouchname) > -1) {
-                //console.log(new Date() + " This role is for this corpus: " + role);
-                if (thisUsersMask.username === requestingUser) {
+              role = roles[roleIndex];
+              if (role.indexOf(pouchname + "_") === 0) {
+                userIsOnTeam = true;
+
+                // console.log(new Date() + currentUsername + " is a member of this corpus: " + role);
+                if (currentUsername === requestingUser) {
                   requestingUserIsAMemberOfCorpusTeam = true;
                 }
+
                 /*
                  * If the role is for this corpus, insert the users's mask into
                  * the relevant roles, this permits the creation of new roles in the system
                  */
-                var roleType = role.replace(pouchname + "_", "") + "s";
+                roleType = role.replace(pouchname + "_", "") + "s";
                 rolesAndUsers[roleType] = rolesAndUsers[roleType] || [];
-                rolesAndUsers[roleType].push(thisUsersMask);
+                rolesAndUsers[roleType].push({
+                  username: currentUsername,
+                  gravatar: thisUsersMask.gravatar
+                });
               }
-            });
-
-            if (!userIsOnTeam) {
-              rolesAndUsers.notonteam.push(thisUsersMask);
             }
 
-          });
+            if (!userIsOnTeam) {
+              rolesAndUsers.notonteam.push({
+                username: currentUsername,
+                gravatar: thisUsersMask.gravatar
+              });
+            }
+          }
+
 
           /*
            * Send the results, if the user is part of the team
            */
-          if (!requestingUserIsAMemberOfCorpusTeam) {
-            console.log("rolesAndUsers" + JSON.stringify(rolesAndUsers));
-          }
           if (requestingUserIsAMemberOfCorpusTeam) {
             done(null, rolesAndUsers, {
               message: "Look up successful."
             });
           } else {
+            console.log("Requesting user `" + requestingUser + "` is not a member of the corpus team." + pouchname);
             done({
               status: 401,
               error: "Requesting user `" + requestingUser + "` is not a member of the corpus team.",

--- a/lib/userauthentication.js
+++ b/lib/userauthentication.js
@@ -1172,6 +1172,53 @@ module.exports.fetchCorpusPermissions = function(req, done) {
             }
           }
 
+          /* sort alphabetically the real roles (typeaheads dont matter) */
+          if (rolesAndUsers.admins) {
+            rolesAndUsers.admins.sort(function(a, b) {
+              if (a.username < b.username) {
+                return -1;
+              }
+              if (a.username > b.username) {
+                return 1;
+              }
+              return 0;
+            });
+          }
+          if (rolesAndUsers.writers) {
+            rolesAndUsers.writers.sort(function(a, b) {
+              if (a.username < b.username) {
+                return -1;
+              }
+              if (a.username > b.username) {
+                return 1;
+              }
+              return 0;
+            });
+          }
+
+          if (rolesAndUsers.readers) {
+            rolesAndUsers.readers.sort(function(a, b) {
+              if (a.username < b.username) {
+                return -1;
+              }
+              if (a.username > b.username) {
+                return 1;
+              }
+              return 0;
+            });
+          }
+          if (rolesAndUsers.commenters) {
+            rolesAndUsers.commenters.sort(function(a, b) {
+              if (a.username < b.username) {
+                return -1;
+              }
+              if (a.username > b.username) {
+                return 1;
+              }
+              return 0;
+            });
+          }
+
 
           /*
            * Send the results, if the user is part of the team

--- a/lib/userauthentication.js
+++ b/lib/userauthentication.js
@@ -65,7 +65,7 @@ if (emailWhenServerStarts !== "") {
 module.exports = {};
 
 
-validateIdentifier = function(originalIdentifier) {
+var validateIdentifier = function(originalIdentifier) {
   var identifier = originalIdentifier.toString();
   var changes = [];
   if (identifier.toLowerCase() !== identifier) {
@@ -178,14 +178,10 @@ module.exports.registerNewUser = function(localOrNot, req, done) {
       if (appbrand === "georgiantogether") {
         couchConnection.pouchname = req.body.username + "-kartuli";
       }
+      couchConnection.dbname = couchConnection.pouchname;
+
       var activityCouchConnection = JSON.parse(JSON.stringify(couchConnection));
-      activityCouchConnection.pouchname = req.body.username + "-activity_feed";
-
-      var corpora = [JSON.parse(JSON.stringify(couchConnection))];
-
-      /* Prepare mostRecentIds so apps can load a most recent dashboard if applicable */
-      var mostRecentIds = {};
-      mostRecentIds.couchConnection = JSON.parse(JSON.stringify(couchConnection));
+      activityCouchConnection.pouchname = activityCouchConnection.dbname = req.body.username + "-activity_feed";
 
       /* Set gravatar using the user's registered email, or username if none */
       var gravatar = null;
@@ -218,6 +214,15 @@ module.exports.registerNewUser = function(localOrNot, req, done) {
       if (appbrand === "kartulispeechrecognition") {
         private_corpus_template.description = "This is your personal database, here you can see the sentences you made for your own speech recognition system trained to your voice and vocabulary. You can share your database with others by adding them to your team as readers, writers, commenters or admins on your database.";
       }
+      couchConnection.title = corpusTitle;
+      couchConnection.description = private_corpus_template.description;
+      private_corpus_template.titleAsUrl = couchConnection.titleAsUrl = corpusTitle.toLowerCase().replace(/[^a-z0-9_]/g, "_");
+
+      var corpora = [JSON.parse(JSON.stringify(couchConnection))];
+
+      /* Prepare mostRecentIds so apps can load a most recent dashboard if applicable */
+      var mostRecentIds = {};
+      mostRecentIds.couchConnection = JSON.parse(JSON.stringify(couchConnection));
 
       /* Prepare a public corpus doc for the user's first corpus */
       var public_corpus_template = corpus.createPublicCorpusDoc(couchConnection, couchConnection.pouchname);
@@ -1183,7 +1188,7 @@ module.exports.fetchCorpusPermissions = function(req, done) {
             });
             for (roleIndex = roles.length - 1; roleIndex >= 0; roleIndex--) {
 
-              role = roles[roleIndex];
+              var role = roles[roleIndex];
               if (role.indexOf(pouchname + "_") === 0) {
                 userIsOnTeam = true;
 
@@ -1581,14 +1586,14 @@ var findById = function(id, done) {
  * This function uses findById since we have decided to save usernames as id's
  * in the couchdb
  */
-findByUsername = function(username, done) {
+var findByUsername = function(username, done) {
   return findById(username, done);
 };
 
 /**
  * This function uses tries to look up users by email
  */
-findByEmail = function(email, optionallyRestrictToIncorrectLoginAttempts, done) {
+var findByEmail = function(email, optionallyRestrictToIncorrectLoginAttempts, done) {
 
   var usersQuery = "usersByEmail";
   if (optionallyRestrictToIncorrectLoginAttempts) {

--- a/lib/userauthentication.js
+++ b/lib/userauthentication.js
@@ -1033,8 +1033,11 @@ module.exports.fetchCorpusPermissions = function(req, done) {
    * https://127.0.0.1:6984/_users/_design/users/_view/userroles
    */
   var usersdb = nanoforpermissions.db.use("_users");
-
-  usersdb.view("users", "userroles", function(error, body) {
+  var whichUserGroup = "normalusers";
+  if (doc.username.indexOf("test") > -1 || doc.username.indexOf("anonymous") > -1) {
+    whichUserGroup = "betatesters";
+  }
+  usersdb.view("users", whichUserGroup, function(error, body) {
     if (error) {
       console.log(new Date() + " Error quering userroles: " + util.inspect(error));
       console.log(new Date() + " This is the results recieved: " + util.inspect(body));

--- a/lib/userauthentication.js
+++ b/lib/userauthentication.js
@@ -412,17 +412,19 @@ module.exports.registerNewUser = function(localOrNot, req, done) {
 
 var emailWelcomeToTheUser = function(user) {
   /* all is well, the corpus was created. welcome the user */
-  if (!user.email) {
-    user.email = "bounce@lingsync.org";
+  var email = user.email || "";
+  email = email + "";
+  if (!email) {
+    email = "bounce@lingsync.org";
   }
-  if (user.email && user.email.length > 5 && mail_config.mailConnection.auth.user !== "") {
+  if (email && email.length > 5 && mail_config.mailConnection.auth.user !== "") {
     // Send email https://github.com/andris9/Nodemailer
     var smtpTransport = nodemailer.createTransport("SMTP", mail_config.mailConnection);
     var mailOptions = mail_config.newUserMailOptions();
     if (user.appbrand === "phophlo") {
       mailOptions = mail_config.newUserMailOptionsPhophlo();
     }
-    mailOptions.to = user.email + "," + mailOptions.to;
+    mailOptions.to = email + "," + mailOptions.to;
     mailOptions.text = mailOptions.text.replace(/insert_username/g, user.username);
     mailOptions.html = mailOptions.html.replace(/insert_username/g, user.username);
     smtpTransport.sendMail(mailOptions, function(error, response) {
@@ -430,12 +432,12 @@ var emailWelcomeToTheUser = function(user) {
         console.log(new Date() + " Mail error" + util.inspect(error));
       } else {
         console.log(new Date() + " Message sent: \n" + response.message);
-        console.log(new Date() + " Sent User " + user.username + " a welcome email at " + user.email);
+        console.log(new Date() + " Sent User " + user.username + " a welcome email at " + email);
       }
       smtpTransport.close(); // shut down the connection pool
     });
   } else {
-    console.log(new Date() + " Didn't email welcome to new user" + user.username + " why: emailpresent: " + user.email + ", valid user email: " + (user.email.length > 5) + ", mailconfig: " + (mail_config.mailConnection.auth.user !== ""));
+    console.log(new Date() + " Didn't email welcome to new user" + user.username + " why: emailpresent: " + email + ", valid user email: " + (email.length > 5) + ", mailconfig: " + (mail_config.mailConnection.auth.user !== ""));
   }
 };
 
@@ -539,17 +541,19 @@ var emailTemporaryPasswordToTheUserIfTheyHavAnEmail = function(user, temporaryPa
 
 var undoCorpusCreation = function(user, couchConnection, docs) {
   console.log(new Date() + " TODO need to clean up a broken corpus." + util.inspect(couchConnection));
-  if (!user.email) {
-    user.email = "bounce@lingsync.org";
+  var email = user.email || "";
+  email = email + "";
+  if (!email) {
+    email = "bounce@lingsync.org";
   }
   /* Something is wrong with the user's app, for now, notify the user */
-  if (user.email && user.email.length > 5 && mail_config.mailConnection.auth.user !== "") {
+  if (email && email.length > 5 && mail_config.mailConnection.auth.user !== "") {
     var smtpTransport = nodemailer.createTransport("SMTP", mail_config.mailConnection);
     var mailOptions = mail_config.newUserMailOptions();
     if (user.appbrand === "phophlo") {
       mailOptions = mail_config.newUserMailOptionsPhophlo();
     }
-    mailOptions.to = user.email + "," + mailOptions.to;
+    mailOptions.to = email + "," + mailOptions.to;
     mailOptions.text = "There was a problem while registering your user. The server admins have been notified." + user.username;
     mailOptions.html = "There was a problem while registering your user. The server admins have been notified." + user.username;
     smtpTransport.sendMail(mailOptions, function(error, response) {
@@ -557,12 +561,12 @@ var undoCorpusCreation = function(user, couchConnection, docs) {
         console.log(new Date() + " Mail error" + util.inspect(error));
       } else {
         console.log(new Date() + " Message sent: \n" + response.message);
-        console.log(new Date() + " Sent User " + user.username + " a welcome email at " + user.email);
+        console.log(new Date() + " Sent User " + user.username + " a welcome email at " + email);
       }
       smtpTransport.close(); // shut down the connection pool
     });
   } else {
-    console.log(new Date() + " Didnt email welcome to new user" + user.username + " why: emailpresent: " + user.email + ", valid user email: " + (user.email.length > 5) + ", mailconfig: " + (mail_config.mailConnection.auth.user !== ""));
+    console.log(new Date() + " Didnt email welcome to new user" + user.username + " why: emailpresent: " + email + ", valid user email: " + (email.length > 5) + ", mailconfig: " + (mail_config.mailConnection.auth.user !== ""));
   }
 
 };
@@ -802,11 +806,15 @@ module.exports.addRoleToUser = function(req, done) {
   var requestingUser = req.body.username;
   var dbConn = {};
   // If serverCode is present, request is coming from Spreadsheet app
-  if (req.body.serverCode) {
-    dbConn = corpus.getCouchConnectionFromServerCode(req.body.serverCode);
-    dbConn.pouchname = req.body.pouchname;
-  } else {
-    dbConn = req.body.couchConnection;
+  dbConn = req.body.couchConnection;
+
+  if (!dbConn || !dbConn.pouchname || dbConn.pouchname.indexOf("-") === -1) {
+    return done({
+      status: 412,
+      error: "Client didnt define the pouchname to modify."
+    }, null, {
+      message: "This app has made an invalid request. Please notify its developer. missing: corpusidentifier"
+    });
   }
 
   if (!req || !req.body.username || !req.body.username) {
@@ -818,33 +826,134 @@ module.exports.addRoleToUser = function(req, done) {
     });
   }
 
+  if (!req || !req.body.users || req.body.users.length === 0 || !req.body.users[0].username) {
+    return done({
+      status: 412,
+      error: "Client didnt define the username to modify."
+    }, null, {
+      message: "This app has made an invalid request. Please notify its developer. missing: user(s) to modify"
+    });
+  }
+
+  if ((!req.body.users[0].add || req.body.users[0].add.length < 1) && (!req.body.users[0].remove || req.body.users[0].remove.length < 1)) {
+    return done({
+      status: 412,
+      error: "Client didnt define the roles to add nor remove"
+    }, null, {
+      message: "This app has made an invalid request. Please notify its developer. missing: roles to add or remove"
+    });
+  }
+
   corpus.isRequestingUserAnAdminOnCorpus(req, requestingUser, dbConn, function(error, result, messages) {
     if (error) {
       return done(error, result, messages);
     } else {
       console.log(new Date() + " User " + requestingUser + " is admin and can modify permissions on " + dbConn.pouchname);
 
-      var rolesSimpleStrings = req.body.roles;
-      if (!rolesSimpleStrings) {
-        return done({
-          status: 412,
-          error: "Client didnt define the roles to add."
-        }, null, {
-          message: "This app has made an invalid request. Please notify its developer. missing: roles"
-        });
-      }
-      var roles = [];
-      for (var r in rolesSimpleStrings) {
-        roles.push(dbConn.pouchname + "_" + rolesSimpleStrings[r]);
-      }
+      var sanitizeRoles = function(role) {
+        if (role.indexOf("_") > -1) {
+          role = role.substring(role.lastSubstring("_"));
+        }
+        role = dbConn.pouchname + "_" + role;
+        return role;
+      };
 
+      // convert roles into corpus specific roles
+      req.body.users = req.body.users.map(function(userPermission) {
+        if (userPermission.add && typeof userPermission.add.map === "function") {
+          userPermission.add = userPermission.add.map(sanitizeRoles);
+        } else {
+          userPermission.add = [];
+        }
+        if (userPermission.remove && typeof userPermission.remove.map === "function") {
+          userPermission.remove = userPermission.remove.map(sanitizeRoles);
+        } else {
+          userPermission.remove = [];
+        }
+        return userPermission;
+      });
+
+
+      var promises = [];
+      var userModificationResults = [];
+
+      var deferred = Q.defer();
+      promises.push(deferred.promise);
       /*
        * If they are admin, add the role to the user, then add the corpus to user if succesfull
        */
       var doneAddRoleToUser = done;
-      return corpus_management.addRoleToUser(dbConn, req.body.userToAddToRole, roles, function(error, result, info) {
-        addCorpusToUser(error, req.body.userToAddToRole, dbConn, result, doneAddRoleToUser);
-      }, doneAddRoleToUser);
+      corpus_management.addRoleToUser(dbConn, req.body.users[0], function(error, resultOfAddedToCorpusPermissions, info) {
+
+        // return doneAddRoleToUser({
+        //   status: 412,
+        //   error: "TODO"
+        // }, resultOfAddedToCorpusPermissions, {
+        //   message: "TODO after addRoleToUser"
+        // });
+
+        addCorpusToUser(error, req.body.users[0].username, dbConn, resultOfAddedToCorpusPermissions, function() {
+          deffered.resolve("happy");
+        });
+      }, function() {
+        deffered.resolve("sad");
+      });
+
+
+      Q.allSettled(promises).then(function(results) {
+
+        return doneAddRoleToUser({
+          status: 412,
+          error: "TODO"
+        }, resultOfAddedToCorpusPermissions, {
+          message: "TODO after allSettled"
+        });
+
+        console.log(new Date() + " recieved promises back " + results.length)
+        results.forEach(function(result) {
+          if (!result) {
+            return;
+          }
+          if (result.state === "fulfilled") {
+            var value = result.value;
+            if (value.source && value.source.exception) {
+              userModificationResults = userModificationResults + " " + value.source.exception;
+            } else {
+              userModificationResults = userModificationResults + " " + "Success";
+            }
+          } else {
+            // not fulfilled,happens rarely
+            var reason = result.reason;
+            userModificationResults = userModificationResults + " " + reason;
+          }
+        });
+
+        if (userModificationResults.indexOf('Success') > -1) {
+          // At least one user was updated, probably all of htem...
+          returndata.users = req.body.users;
+          returndata.info = req.body.users.map(function(user) {
+            return message;
+          });
+          res.send(returndata);
+          return;
+
+        } else {
+          returndata.userFriendlyErrors = req.body.users.map(function(user) {
+            returndata.status = user.status;
+            res.status(user.status)
+            return message;
+          });
+          res.send(returndata);
+          return;
+        }
+
+      }).fail(function(error) {
+        error.status = error.status || 500;
+        return doneAddRoleToUser(error, resultDetails, {
+          message: "The server was unable to process your request. Please report this 2199."
+        });
+      });
+
 
 
     }
@@ -1001,59 +1110,128 @@ module.exports.fetchCorpusPermissions = function(req, done) {
 
 };
 
-var addCorpusToUser = function(error, username, newcorpusConnection, rolesresult, done) {
+var addCorpusToUser = function(error, username, newcorpusConnection, userPermissionResult, done) {
   if (error) {
     error = error || {};
     error.status = error.status || 500;
+    userPermissionResult.status = err.status;
+    userPermissionResult.message = "The server is unable to respond to this request. Please report this 1289";
     return done(error, null, {
-      message: "The server is unablet to respond to this request. Please report this 1289"
+      message: userPermissionResult.message
     });
   }
   findByUsername(username, function(err, user, info) {
     if (err) {
-      // Don't tell them its because the user doesn't exist.
+      err.status = err.status || 500;
+      userPermissionResult.status = err.status;
+      userPermissionResult.message = 'Username doesnt exist on this server. This is a bug.';
+      // Don't tell them its because the userPermissionResult doesn't exist.
       return done(err, null, {
-        message: 'Username doesnt exist on this server. This is a bug.'
+        message: userPermissionResult.message
       });
     }
     if (!user) {
       // This case is a server error, it should not happen.
-      return done(null, false, {
-        message: 'Server error. 1292'
+      userPermissionResult.status = err.status;
+      userPermissionResult.message = 'Server was unable to process you request. Please report this: 1292';
+      return done({
+        status: 500,
+        error: "There was no error from couch, but also no user."
+      }, false, {
+        message: userPermissionResult.message
       });
+    }
+
+    var shouldEmailWelcomeToCorpusToUser = false;
+    user.serverlogs.welcomeToCorpusEmails = user.serverlogs.welcomeToCorpusEmails || {};
+    if (userPermissionResult.after.length > 0 && !user.serverlogs.welcomeToCorpusEmails[newcorpusConnection.pouchname]) {
+      shouldEmailWelcomeToCorpusToUser = true;
+      user.serverlogs.welcomeToCorpusEmails[newcorpusConnection.pouchname] = [Date.now()];
     }
 
     /*
      * If corpus is already there
      */
     console.log(new Date() + " Here are the user's known corpora" + util.inspect(user.corpuses));
+    var alreadyAdded;
+    for (var couchConnectionIndex = user.corpuses.length - 1; couchConnectionIndex >= 0; couchConnectionIndex--) {
+
+      if (userPermissionResult.after.length === 0) {
+        // removes from all servers, TODO this might be something we should ask the user about. 
+        if (user.corpuses[couchConnectionIndex].pouchname === newcorpusConnection.pouchname) {
+          user.corpuses.splice(couchConnectionIndex, 1);
+        }
+      } else {
+        if (alreadyAdded) {
+          continue;
+        }
+        if (user.corpuses[couchConnectionIndex].pouchname === newcorpusConnection.pouchname) {
+          alreadyAdded = true;
+        }
+      }
+
+    };
+
     var indexOfNewCorpusInExistingCorpuses = _.pluck(user.corpuses, "pouchname").indexOf(newcorpusConnection.pouchname);
-    if (indexOfNewCorpusInExistingCorpuses > -1) {
-      return done(
-        null,
-        rolesresult, {
-          message: 'Added role(s) to user, the user is already a member of this corpus team.'
-        });
+    if (userPermissionResult.after.length > 0) {
+      if (indexOfNewCorpusInExistingCorpuses > -1) {
+        userPermissionResult.status = 200;
+        userPermissionResult.message = 'Modified permission(s) to user, the user is already a member of this corpus team.';
+        return done(
+          null, userPermissionResult, {
+            message: userPermissionResult.message
+          });
+      } else {
+        /*
+         * Add the new db connection to the user, save them and send them an
+         * email telling them they they have access
+         */
+        user.corpuses = user.corpuses || [];
+        user.corpuses.push(newcorpusConnection);
+      }
+    } else {
+      if (indexOfNewCorpusInExistingCorpuses > -1) {
+        user.corpuses.splice(indexOfNewCorpusInExistingCorpuses, 1);
+      }
     }
 
-    /*
-     * Add the new db connection to the user, save them and send them an
-     * email telling them they they have access
-     */
-    user.newCorpusConnections = user.newCorpusConnections || [];
-    user.newCorpusConnections.push(newcorpusConnection);
+    // return done({
+    //   error: "todo",
+    //   status: 412
+    // }, [userPermissionResult, user.corpuses], {
+    //   message: "TODO. save modifying the list of corpora in the user "
+    // });
+
 
     var doneAddingCorpusToUser = done;
     saveUpdateUserToDatabase(user, function(error, user, info) {
       if (error) {
+        error.status = error.status || 505
+        userPermissionResult.status = error.status;
+        userPermissionResult.message = "Modified permission(s) for " + username + " but we weren't able to add this corpus to their account. This is most likely a bug, please report it.";
         return doneAddingCorpusToUser(
           error,
-          rolesresult, {
-            message: "Added role(s) to " + username + " but we weren't able to add this corpus to their account. This is most likely a bug, please report it."
+          userPermissionResult, {
+            message: userPermissionResult.message
           });
       }
+
+      // If the user was removed we can exit now
+      if (userPermissionResult.after.length === 0) {
+        userPermissionResult.status = 400;
+        userPermissionResult.message = "User " + user.username + " was removed from the " +
+          newcorpusConnection.pouchname +
+          " team.";
+        return doneAddingCorpusToUser(
+          null,
+          userPermissionResult, {
+            message: userPermissionResult.message
+          });
+      }
+
+
       // send the user an email to welcome to this corpus team
-      if (user.email && user.email.length > 5 && mail_config.mailConnection.auth.user !== "") {
+      if (shouldEmailWelcomeToCorpusToUser && user.email && user.email.length > 5 && mail_config.mailConnection.auth.user !== "") {
         var smtpTransport = nodemailer.createTransport("SMTP", mail_config.mailConnection);
         var mailOptions = mail_config.welcomeToCorpusTeamMailOptions();
         if (user.appbrand === "phophlo") {
@@ -1066,19 +1244,30 @@ var addCorpusToUser = function(error, username, newcorpusConnection, rolesresult
           if (error) {
             console.log(new Date() + " Mail error" + util.inspect(error));
           } else {
+
             console.log(new Date() + " Message sent: \n" + response.message);
             console.log(new Date() + " Sent User " + user.username + " a welcome to corpus email at " + user.email);
           }
           smtpTransport.close();
         });
+
       } else {
-        console.log(new Date() + " Didnt email welcome to corpus to new user" + user.username + " why: emailpresent: " + user.email + ", valid user email: " + (user.email.length > 5) + ", mailconfig: " + (mail_config.mailConnection.auth.user !== ""));
+        console.log(new Date() + " Didn't email welcome to corpus to new user " +
+          user.username + " why: emailpresent: " + user.email +
+          ", valid user email: " + (user.email.length > 5) +
+          ", mailconfig: " + (mail_config.mailConnection.auth.user !== ""));
+
+        userPermissionResult.status = 200;
+        userPermissionResult.message = 'User ' + user.username + ' has ' +
+          userPermissionResult.after.join(" ") + " access to " +
+          newcorpusConnection.pouchname
+        return doneAddingCorpusToUser(
+          null,
+          userPermissionResult, {
+            message: userPermissionResult.message
+          });
       }
-      return doneAddingCorpusToUser(
-        null,
-        rolesresult, {
-          message: 'Added role(s) to user, and the user was emailed to tell them that they have been added to this corpus team.'
-        });
+
     });
 
   });

--- a/lib/userauthentication.js
+++ b/lib/userauthentication.js
@@ -885,8 +885,6 @@ module.exports.addRoleToUser = function(req, done) {
 
     var promises = [];
 
-    var deferred = Q.defer();
-    promises.push(deferred.promise);
     /*
      * If they are admin, add the role to the user, then add the corpus to user if succesfull
      */
@@ -895,8 +893,10 @@ module.exports.addRoleToUser = function(req, done) {
       var sameTempPasswordForAllTheirUsers = makeRandomPassword();
 
       (function(userPermission) {
+        var deferred = Q.defer();
+        promises.push(deferred.promise);
 
-        corpus_management.addRoleToUser(dbConn, req.body.users[0], function(error, resultOfAddedToCorpusPermissions, info) {
+        corpus_management.addRoleToUser(dbConn, req.body.users[userIndex], function(error, resultOfAddedToCorpusPermissions, info) {
 
           // return done({
           //   status: 412,
@@ -908,25 +908,25 @@ module.exports.addRoleToUser = function(req, done) {
           addCorpusToUser(error, userPermission.username, dbConn, resultOfAddedToCorpusPermissions, function(error, resultOfAddedToCorpusPermissions, info) {
             console.log(" Bringing in mesages and status from successful user result.");
             console.log(userPermission);
-            console.log(resultOfAddedToCorpusPermissions);
-            for (var attrib in resultOfAddedToCorpusPermissions) {
-              if (!resultOfAddedToCorpusPermissions.hasOwnProperty(attrib)) {
-                continue;
-              }
-              userPermission[attrib] = resultOfAddedToCorpusPermissions[attrib];
-            }
+            // console.log(resultOfAddedToCorpusPermissions);
+            // for (var attrib in resultOfAddedToCorpusPermissions) {
+            //   if (!resultOfAddedToCorpusPermissions.hasOwnProperty(attrib)) {
+            //     continue;
+            //   }
+            //   userPermission[attrib] = resultOfAddedToCorpusPermissions[attrib];
+            // }
             deferred.resolve("happy");
           });
         }, function(error, resultOfAddedToCorpusPermissions, info) {
           console.log(" Bringing in mesages and status from failing user result.");
           console.log(userPermission);
-          console.log(resultOfAddedToCorpusPermissions);
-          for (var attrib in resultOfAddedToCorpusPermissions) {
-            if (!resultOfAddedToCorpusPermissions.hasOwnProperty(attrib)) {
-              continue;
-            }
-            userPermission[attrib] = resultOfAddedToCorpusPermissions[attrib];
-          }
+          // console.log(resultOfAddedToCorpusPermissions);
+          // for (var attrib in resultOfAddedToCorpusPermissions) {
+          //   if (!resultOfAddedToCorpusPermissions.hasOwnProperty(attrib)) {
+          //     continue;
+          //   }
+          //   userPermission[attrib] = resultOfAddedToCorpusPermissions[attrib];
+          // }
           deferred.resolve("sad");
         });
 

--- a/lib/userauthentication.js
+++ b/lib/userauthentication.js
@@ -11,7 +11,9 @@ var util = require('util'),
   corpus_management = require('./corpusmanagement'),
   uuid = require('uuid'),
   corpus = require('./corpus'),
-  Q = require('q');
+  Q = require('q'),
+  Diacritics = require("diacritic");
+
 
 /* variable for permissions */
 var collaborator = "reader";
@@ -62,6 +64,45 @@ if (emailWhenServerStarts !== "") {
  */
 module.exports = {};
 
+
+validateIdentifier = function(originalIdentifier) {
+  var identifier = originalIdentifier.toString();
+  var changes = [];
+  if (identifier.toLowerCase() !== identifier) {
+    changes.push("The identifier has to be lowercase so that it can be used in your CouchDB database names.");
+    identifier = identifier.toLowerCase();
+  }
+
+  if (identifier.split("-").length > 1) {
+    changes.push("We are using - as a reserved symbol in database names, so you can't use it in your identifier.");
+    identifier = identifier.replace("-", ":::").replace(/-/g, "_").replace(":::", "-");
+  }
+
+  if (Diacritics.clean(identifier) !== identifier) {
+    changes.push("You have to use ascii characters in your identifiers because your identifier is used in your in web urls, so its better if you can use something more web friendly.");
+    identifier = Diacritics.clean(identifier);
+  }
+
+  if (identifier.replace(/[^a-z0-9_-]/g, "_") !== identifier) {
+    changes.push("You have some characters which web servers wouldn't trust in your identifier.");
+    identifier = identifier.replace(/[^a-z0-9_]/g, "_");
+  }
+
+  if (identifier.length < 2) {
+    changes.push("Your identifier is really too short.");
+  }
+
+  if (changes.length > 0) {
+    changes.unshift("You asked to use " + originalIdentifier + " but we would reccomend using this instead: " + identifier + " the following are a list of reason's why.");
+  }
+
+  return {
+    "identifier": identifier,
+    "original": originalIdentifier,
+    "changes": changes
+  };
+};
+
 /**
  * Takes parameters from the request and creates a new user json, salts and
  * hashes the password, has the corpus_management library create a new couchdb
@@ -96,19 +137,19 @@ module.exports.registerNewUser = function(localOrNot, req, done) {
     });
   }
 
-  var safeUsernameForCouchDB = req.body.username.trim().toLowerCase().replace(/[^0-9a-z]/g, "");
-  if (req.body.username !== safeUsernameForCouchDB) {
-    return done({
-      status: 406,
-      error: 'The username :' + req.body.username + ': was not a safe username user, requested the user to change it to: ' + safeUsernameForCouchDB
-    }, null, {
-      message: 'Please use \'' + safeUsernameForCouchDB + '\' instead (the username you have chosen isn\'t very safe for urls, which means your corpora would be potentially inaccessible in old browsers)'
+  var safeUsernameForCouchDB = validateIdentifier(req.body.username);
+  if (req.body.username !== safeUsernameForCouchDB.identifier) {
+    safeUsernameForCouchDB.status = 406;
+    return done(safeUsernameForCouchDB, null, {
+      message: 'Please use \'' + safeUsernameForCouchDB.identifier + '\' instead (the username you have chosen isn\'t very safe for urls, which means your corpuses would be potentially inaccessible in old browsers)'
     });
   }
 
   // Make sure the username doesn't exist.
   findByUsername(req.body.username, function(err, user, info) {
     if (user) {
+      err = err || {};
+      err.status = err.status || 409;
       return done(err, null, {
         message: 'Username already exists, try a different username.'
       });
@@ -122,18 +163,20 @@ module.exports.registerNewUser = function(localOrNot, req, done) {
 
       // Create couchConnection and activityCouchConnection based on server
       // code in request TODO what does serverCode look like or mean? maybe too ambiguous?
-      var serverCode = req.body.serverCode;
+      var serverCode = req.body.serverCode || req.body.serverLabel || "production";
+      var appbrand = req.body.appbrand || "lingsync";
+
       //TODO this has to be come asynchonous if this design is a central server who can register users on other servers
-      var couchConnection = corpus.getCouchConnectionFromServerCode(serverCode);
+      var couchConnection = req.body.couchConnection || req.body.corpusConnection || corpus.getCouchConnectionFromServerCode(serverCode);
       couchConnection.pouchname = req.body.username + "-firstcorpus";
-      if (serverCode === "phophlo") {
+      if (appbrand === "phophlo") {
         couchConnection.pouchname = req.body.username + "-phophlo";
       }
-      if (serverCode === "kartulispeechrecognition") {
+      if (appbrand === "kartulispeechrecognition") {
         couchConnection.pouchname = req.body.username + "-kartuli";
       }
-      if (serverCode === "georgiantogether") {
-        couchConnection.pouchname = req.body.username + "-georgian";
+      if (appbrand === "georgiantogether") {
+        couchConnection.pouchname = req.body.username + "-kartuli";
       }
       var activityCouchConnection = JSON.parse(JSON.stringify(couchConnection));
       activityCouchConnection.pouchname = req.body.username + "-activity_feed";
@@ -156,23 +199,23 @@ module.exports.registerNewUser = function(localOrNot, req, done) {
 
       /* Prepare a private corpus doc for the user's first corpus */
       var corpusTitle = "Practice Corpus";
-      if (serverCode === "phophlo") {
+      if (appbrand === "phophlo") {
         corpusTitle = "Phophlo";
       }
-      if (serverCode === "georgiantogether") {
+      if (appbrand === "georgiantogether") {
         corpusTitle = "Geogian";
       }
-      if (serverCode === "kartulispeechrecognition") {
+      if (appbrand === "kartulispeechrecognition") {
         corpusTitle = "Kartuli Speech Recognition";
       }
       var private_corpus_template = corpus.createPrivateCorpusDoc(req.body.username, corpusTitle, couchConnection, couchConnection.pouchname);
-      if (serverCode === "phophlo") {
+      if (appbrand === "phophlo") {
         private_corpus_template.description = "This is your Phophlo database, here you can see your imported class lists and participants results. You can share your database with others by adding them to your team as readers, writers, commenters or admins on your database.";
       }
-      if (serverCode === "georgiantogether") {
+      if (appbrand === "georgiantogether") {
         private_corpus_template.description = "This is your Georgian database, here you can see the lessons you made for your self. You can share your database with others by adding them to your team as readers, writers, commenters or admins on your database.";
       }
-      if (serverCode === "kartulispeechrecognition") {
+      if (appbrand === "kartulispeechrecognition") {
         private_corpus_template.description = "This is your personal database, here you can see the sentences you made for your own speech recognition system trained to your voice and vocabulary. You can share your database with others by adding them to your team as readers, writers, commenters or admins on your database.";
       }
 
@@ -289,7 +332,7 @@ module.exports.registerNewUser = function(localOrNot, req, done) {
         "email": req.body.email,
         "corpuses": corpuses,
         "activityCouchConnection": activityCouchConnection,
-        "appbrand": serverCode || "lingsync",
+        "appbrand": appbrand,
 
         "gravatar": gravatar,
         "researchInterest": req.body.researchInterest || "",
@@ -330,7 +373,7 @@ module.exports.registerNewUser = function(localOrNot, req, done) {
         "_id": user._id,
         "gravatar": user.gravatar,
         "username": user.username,
-        "appbrand": serverCode || "lingsync",
+        "appbrand": appbrand,
         "collection": "users",
         "firstname": "",
         "lastname": "",
@@ -601,13 +644,11 @@ module.exports.authenticateUser = function(username, password, req, done) {
   }
 
 
-  var safeUsernameForCouchDB = username.trim().toLowerCase().replace(/[^0-9a-z]/g, "");
-  if (username !== safeUsernameForCouchDB) {
-    return done({
-      status: 406,
-      error: 'The username ' + username + ' was not a real user, and potentially trying to do somethign dangerous. ' + safeUsernameForCouchDB
-    }, null, {
-      message: 'Username or password is invalid. Maybe your username is ' + safeUsernameForCouchDB + '?'
+  var safeUsernameForCouchDB = validateIdentifier(username.trim());
+  if (username !== safeUsernameForCouchDB.identifier) {
+    safeUsernameForCouchDB.status = safeUsernameForCouchDB.status || 406
+    return done(safeUsernameForCouchDB, null, {
+      message: 'Username or password is invalid. Maybe your username is ' + safeUsernameForCouchDB.identifier + '?'
     });
   }
 

--- a/lib/userauthentication.js
+++ b/lib/userauthentication.js
@@ -28,7 +28,7 @@ var commenter = "commenter";
 var dontCreateDBsForLearnXUsersBecauseThereAreTooManyOfThem = true;
 
 
-var authServerVersion = "2.12.0";
+var authServerVersion = require("package").version;
 
 //Only create users on the same server.
 var parsed = url.parse("http://localhost:5984");
@@ -1033,6 +1033,7 @@ module.exports.fetchCorpusPermissions = function(req, done) {
    * https://127.0.0.1:6984/_users/_design/users/_view/userroles
    */
   var usersdb = nanoforpermissions.db.use("_users");
+
   usersdb.view("users", "userroles", function(error, body) {
     if (error) {
       console.log(new Date() + " Error quering userroles: " + util.inspect(error));

--- a/lib/userauthentication.js
+++ b/lib/userauthentication.js
@@ -141,7 +141,7 @@ module.exports.registerNewUser = function(localOrNot, req, done) {
   if (req.body.username !== safeUsernameForCouchDB.identifier) {
     safeUsernameForCouchDB.status = 406;
     return done(safeUsernameForCouchDB, null, {
-      message: 'Please use \'' + safeUsernameForCouchDB.identifier + '\' instead (the username you have chosen isn\'t very safe for urls, which means your corpuses would be potentially inaccessible in old browsers)'
+      message: 'Please use \'' + safeUsernameForCouchDB.identifier + '\' instead (the username you have chosen isn\'t very safe for urls, which means your corpora would be potentially inaccessible in old browsers)'
     });
   }
 
@@ -181,7 +181,7 @@ module.exports.registerNewUser = function(localOrNot, req, done) {
       var activityCouchConnection = JSON.parse(JSON.stringify(couchConnection));
       activityCouchConnection.pouchname = req.body.username + "-activity_feed";
 
-      var corpuses = [JSON.parse(JSON.stringify(couchConnection))];
+      var corpora = [JSON.parse(JSON.stringify(couchConnection))];
 
       /* Prepare mostRecentIds so apps can load a most recent dashboard if applicable */
       var mostRecentIds = {};
@@ -330,7 +330,7 @@ module.exports.registerNewUser = function(localOrNot, req, done) {
         "username": req.body.username,
         "_id": req.body.username,
         "email": req.body.email,
-        "corpuses": corpuses,
+        "corpora": corpora,
         "activityCouchConnection": activityCouchConnection,
         "appbrand": appbrand,
 
@@ -388,7 +388,7 @@ module.exports.registerNewUser = function(localOrNot, req, done) {
       var userforcouchdb = {
         "username": req.body.username,
         "password": req.body.password,
-        "corpuses": [JSON.parse(JSON.stringify(couchConnection))],
+        "corpora": [JSON.parse(JSON.stringify(couchConnection))],
         "activityCouchConnection": activityCouchConnection
       };
 
@@ -407,7 +407,7 @@ module.exports.registerNewUser = function(localOrNot, req, done) {
         return saveUpdateUserToDatabase(user, done);
       }
 
-      corpus_management.createDbaddUser(userforcouchdb.corpuses[0], userforcouchdb, function(res) {
+      corpus_management.createDbaddUser(userforcouchdb.corpora[0], userforcouchdb, function(res) {
         console.log(new Date() + " There was success in creating the corpus: " + util.inspect(res) + "\n");
 
         /* Save corpus, datalist and session docs so that apps can load the dashboard for the user */
@@ -447,7 +447,7 @@ module.exports.registerNewUser = function(localOrNot, req, done) {
         });
 
       });
-      console.log(new Date() + " Sent command to create user's corpus to couch: " + util.inspect(user.corpuses[user.corpuses.length - 1]));
+      console.log(new Date() + " Sent command to create user's corpus to couch: " + util.inspect(user.corpora[user.corpora.length - 1]));
 
     }
   });
@@ -542,7 +542,7 @@ var emailTemporaryPasswordToTheUserIfTheyHavAnEmail = function(user, temporaryPa
 
     console.log(new Date() + " Temporary pasword sent: \n" + response.message);
 
-    var couchConnection = user.corpuses[user.corpuses.length - 1];
+    var couchConnection = user.corpora[user.corpora.length - 1];
     // save new password to couch _users too
     corpus_management.changeUsersPassword(
       couchConnection,
@@ -727,7 +727,7 @@ module.exports.authenticateUser = function(username, password, req, done) {
                 });
                 // save new password to couch too
                 corpus_management.changeUsersPassword(
-                  user.corpuses[user.corpuses.length - 1],
+                  user.corpora[user.corpora.length - 1],
                   user,
                   newpassword,
                   function(res) {
@@ -790,22 +790,22 @@ module.exports.authenticateUser = function(username, password, req, done) {
       if (req.body.syncDetails == "true") {
         console.log(new Date() + " Here is syncUserDetails: " + util.inspect(req.body.syncUserDetails));
 
-        if (JSON.stringify(user.corpuses) != JSON.stringify(req.body.syncUserDetails.corpuses)) {
+        if (JSON.stringify(user.corpora) != JSON.stringify(req.body.syncUserDetails.corpora)) {
           console.log(new Date() + " It looks like the user has created some new local offline corpora. Attempting to make new corpus on the team server so the user can download them.");
           var userforcouchdb = {
             username: req.body.username,
             password: req.body.password,
-            corpuses: req.body.syncUserDetails.corpuses,
+            corpora: req.body.syncUserDetails.corpora,
             activityCouchConnection: req.body.activityCouchConnection
           };
           createNewCorpusesIfDontExist(user, userforcouchdb,
-            req.body.syncUserDetails.corpuses);
+            req.body.syncUserDetails.corpora);
 
         } else {
-          console.log(new Date() + " User's corpuses are unchanged.");
+          console.log(new Date() + " User's corpora are unchanged.");
         }
         /* Users details which can come from a client side must be added here, otherwise they are not saved on sync. */
-        user.corpuses = req.body.syncUserDetails.corpuses;
+        user.corpora = req.body.syncUserDetails.corpora;
         user.email = req.body.syncUserDetails.email;
         user.gravatar = req.body.syncUserDetails.gravatar;
         user.researchInterest = req.body.syncUserDetails.researchInterest;
@@ -1330,27 +1330,27 @@ var addCorpusToUser = function(error, username, newcorpusConnection, userPermiss
     /*
      * If corpus is already there
      */
-    console.log(new Date() + " Here are the user's known corpora" + util.inspect(user.corpuses));
+    console.log(new Date() + " Here are the user's known corpora" + util.inspect(user.corpora));
     var alreadyAdded;
-    for (var couchConnectionIndex = user.corpuses.length - 1; couchConnectionIndex >= 0; couchConnectionIndex--) {
+    for (var couchConnectionIndex = user.corpora.length - 1; couchConnectionIndex >= 0; couchConnectionIndex--) {
 
       if (userPermissionResult.after.length === 0) {
         // removes from all servers, TODO this might be something we should ask the user about. 
-        if (user.corpuses[couchConnectionIndex].pouchname === newcorpusConnection.pouchname) {
-          user.corpuses.splice(couchConnectionIndex, 1);
+        if (user.corpora[couchConnectionIndex].pouchname === newcorpusConnection.pouchname) {
+          user.corpora.splice(couchConnectionIndex, 1);
         }
       } else {
         if (alreadyAdded) {
           continue;
         }
-        if (user.corpuses[couchConnectionIndex].pouchname === newcorpusConnection.pouchname) {
+        if (user.corpora[couchConnectionIndex].pouchname === newcorpusConnection.pouchname) {
           alreadyAdded = true;
         }
       }
 
     };
 
-    var indexOfNewCorpusInExistingCorpuses = _.pluck(user.corpuses, "pouchname").indexOf(newcorpusConnection.pouchname);
+    var indexOfNewCorpusInExistingCorpuses = _.pluck(user.corpora, "pouchname").indexOf(newcorpusConnection.pouchname);
     if (userPermissionResult.after.length > 0) {
       if (indexOfNewCorpusInExistingCorpuses > -1) {
         userPermissionResult.status = 200;
@@ -1366,19 +1366,19 @@ var addCorpusToUser = function(error, username, newcorpusConnection, userPermiss
          * Add the new db connection to the user, save them and send them an
          * email telling them they they have access
          */
-        user.corpuses = user.corpuses || [];
-        user.corpuses.unshift(newcorpusConnection);
+        user.corpora = user.corpora || [];
+        user.corpora.unshift(newcorpusConnection);
       }
     } else {
       if (indexOfNewCorpusInExistingCorpuses > -1) {
-        user.corpuses.splice(indexOfNewCorpusInExistingCorpuses, 1);
+        user.corpora.splice(indexOfNewCorpusInExistingCorpuses, 1);
       }
     }
 
     // return done({
     //   error: "todo",
     //   status: 412
-    // }, [userPermissionResult, user.corpuses], {
+    // }, [userPermissionResult, user.corpora], {
     //   message: "TODO. save modifying the list of corpora in the user "
     // });
 
@@ -1456,13 +1456,13 @@ var addCorpusToUser = function(error, username, newcorpusConnection, userPermiss
 
 };
 
-var createNewCorpusesIfDontExist = function(user, userforcouchdb, corpuses) {
+var createNewCorpusesIfDontExist = function(user, userforcouchdb, corpora) {
   /*
    * Creates the user's new corpus databases
    */
-  for (var potentialnewcorpus in corpuses) {
+  for (var potentialnewcorpus in corpora) {
     corpus_management.createDBforCorpus(
-      userforcouchdb.corpuses[potentialnewcorpus],
+      userforcouchdb.corpora[potentialnewcorpus],
       userforcouchdb,
 
       function(corpusConnectionThatWasCreated) {
@@ -1559,6 +1559,10 @@ var findById = function(id, done) {
     } else {
       if (result) {
         console.log(new Date() + ' User ' + id + ' found: \n' + result._id);
+
+        result.corpora = result.corpora || result.corpuses;
+        delete result.corpuses;
+
         return done(null, result, null);
       } else {
         console.log(new Date() + ' No User found: ' + id);
@@ -1712,7 +1716,7 @@ var setPassword = function(oldpassword, newpassword, username, done) {
         user.hash = bcrypt.hashSync(newpassword, salt);
         console.log(salt, user.hash);
         // Save new password to couch too
-        corpus_management.changeUsersPassword(user.corpuses[user.corpuses.length - 1], user, newpassword,
+        corpus_management.changeUsersPassword(user.corpora[user.corpora.length - 1], user, newpassword,
           function(res) {
             console
               .log(new Date() + " There was success in creating changing the couchdb password: " + util.inspect(res) + "\n");

--- a/lib/userauthentication.js
+++ b/lib/userauthentication.js
@@ -1116,7 +1116,8 @@ module.exports.fetchCorpusPermissions = function(req, done) {
             userIsOnTeam = false;
             thisUsersMask = usershash[currentUsername];
             if (!thisUsersMask.gravatar && thisUsersMask.gravatar_email) {
-              // thisUsersMask.gravatar = md5(thisUsersMask.gravatar_email);
+              console.log(new Date() = " regenerating the gravtar of this user :( ", thisUsersMask);
+              thisUsersMask.gravatar = md5(thisUsersMask.gravatar_email);
             }
 
             // Add this user to the typeahead

--- a/lib/userauthentication.js
+++ b/lib/userauthentication.js
@@ -1326,7 +1326,7 @@ var addCorpusToUser = function(error, username, newcorpusConnection, userPermiss
          * email telling them they they have access
          */
         user.corpuses = user.corpuses || [];
-        user.corpuses.push(newcorpusConnection);
+        user.corpuses.unshift(newcorpusConnection);
       }
     } else {
       if (indexOfNewCorpusInExistingCorpuses > -1) {

--- a/lib/userauthentication.js
+++ b/lib/userauthentication.js
@@ -471,7 +471,7 @@ var emailTemporaryPasswordToTheUserIfTheyHavAnEmail = function(user, temporaryPa
         error: "The mail configuration is missing a user, this server cant send email."
       },
       null, {
-        message: "The server was unable to send you an email, your password has not been reset. Please report this 2893"
+        message: "The server was unable to send you an email, your password has not been reset. Please report this 2823"
       });
   }
 
@@ -936,6 +936,7 @@ module.exports.addRoleToUser = function(req, done) {
 
 
 
+    var sentDone = false;
     Q.allSettled(promises).then(function(results) {
       var userModificationResults = [];
 
@@ -961,14 +962,18 @@ module.exports.addRoleToUser = function(req, done) {
       // });
       req.body.users.map(function(userPermis) {
         if (userPermis.status === 200) {
-          done(null, req.body.users);
+          if (!sentDone) {
+            sentDone = true;
+            done(null, req.body.users);
+          }
         }
       });
-
-      done({
-        status: req.body.users[0].status,
-        error: "One or more of the add roles requsts failed. " + req.body.users[0].message
-      }, req.body.users);
+      if (!sentDone) {
+        done({
+          status: req.body.users[0].status,
+          error: "One or more of the add roles requsts failed. " + req.body.users[0].message
+        }, req.body.users);
+      }
 
     });
     // .fail(function(error) {
@@ -1163,6 +1168,7 @@ var addCorpusToUser = function(error, username, newcorpusConnection, userPermiss
     }
 
     var shouldEmailWelcomeToCorpusToUser = false;
+    user.serverlogs = user.serverlogs || {};
     user.serverlogs.welcomeToCorpusEmails = user.serverlogs.welcomeToCorpusEmails || {};
     if (userPermissionResult.after.length > 0 && !user.serverlogs.welcomeToCorpusEmails[newcorpusConnection.pouchname]) {
       shouldEmailWelcomeToCorpusToUser = true;
@@ -1604,7 +1610,7 @@ var forgotPassword = function(email, done) {
   }
 
 
-  var user = findByEmail(email, "onlyUsersWithIncorrectLogins", function(error, users, info) {
+  findByEmail(email, "onlyUsersWithIncorrectLogins", function(error, users, info) {
     if (error) {
       // console.log(new Date() + " Error looking up user  " + username + " : " + util.inspect(error));
       error.status = error.status || 500;

--- a/lib/userauthentication.js
+++ b/lib/userauthentication.js
@@ -1024,7 +1024,7 @@ module.exports.fetchCorpusPermissions = function(req, done) {
   if (dbConn && dbConn.domain && dbConn.domain.indexOf("iriscouch") > -1) {
     dbConn.port = "6984";
   }
-  console.log(new Date() + " Looking for corpus permissions on localhost: ");
+  console.log(new Date() + " " + requestingUser + " requested the team on " + pouchname);
   var nanoforpermissions = require('nano')(couchConnectUrl);
 
   /*
@@ -1094,16 +1094,22 @@ module.exports.fetchCorpusPermissions = function(req, done) {
             usershash[key].roles = userroles[userIndex].value;
           };
 
-          // Put the gravatars in
+          // Put the gravatars in for users who are in this category
           for (userIndex = usermasks.length - 1; userIndex >= 0; userIndex--) {
-            if (!usermasks[3].value || !usermasks[3].value.username) {
+            if (!usermasks[userIndex].value || !usermasks[userIndex].value.username) {
               continue;
             }
-            key = usermasks[3].value.username;
+            key = usermasks[userIndex].value.username;
+            //if this usermask isnt in this category of users, skip them. 
+            if (!usershash[key]) {
+              continue;
+            }
             // console.log(key, usershash[key]);
             usershash[key] = usershash[key] || {};
             usershash[key].username = usermasks[userIndex].value.username;
             usershash[key].gravatar = usermasks[userIndex].value.gravatar;
+            // console.log(new Date() + "  the value of this user ", usermasks[userIndex]);
+
             usershash[key].gravatar_email = usermasks[userIndex].value.gravatar_email;
           }
 
@@ -1115,23 +1121,25 @@ module.exports.fetchCorpusPermissions = function(req, done) {
             // console.log(new Date() + " Looking at " + currentUsername);
             userIsOnTeam = false;
             thisUsersMask = usershash[currentUsername];
-            if (!thisUsersMask.gravatar && thisUsersMask.gravatar_email) {
-              console.log(new Date() = " regenerating the gravtar of this user :( ", thisUsersMask);
+            if ((!thisUsersMask.gravatar || thisUsersMask.gravatar.indexOf("user_gravatar") > -1) && thisUsersMask.gravatar_email) {
+              console.log(new Date() + "  the gravtar of " + currentUsername + " was missing/old ", thisUsersMask);
               thisUsersMask.gravatar = md5(thisUsersMask.gravatar_email);
             }
+
+
+            // Find out if this user is a member of the team
+            roles = thisUsersMask.roles;
+            if (!roles) {
+              console.log(new Date() + " this is odd, " + currentUsername + " doesnt have any roles defined, skipping this user, even for hte typeahead");
+              continue;
+            }
+
 
             // Add this user to the typeahead
             rolesAndUsers.allusers.push({
               username: currentUsername,
               gravatar: thisUsersMask.gravatar
             });
-
-            // Find out if this user is a member of the team
-            roles = thisUsersMask.roles;
-            if (!roles) {
-              console.log(new Date() + " this is odd, " + currentUsername + " doesnt have any roles defined");
-              roles = [];
-            }
             for (roleIndex = roles.length - 1; roleIndex >= 0; roleIndex--) {
 
               role = roles[roleIndex];

--- a/lib/userauthentication.js
+++ b/lib/userauthentication.js
@@ -809,6 +809,7 @@ module.exports.addRoleToUser = function(req, done) {
   dbConn = req.body.couchConnection;
 
   if (!dbConn || !dbConn.pouchname || dbConn.pouchname.indexOf("-") === -1) {
+    console.log(dbConn);
     return done({
       status: 412,
       error: "Client didnt define the pouchname to modify."
@@ -855,7 +856,7 @@ module.exports.addRoleToUser = function(req, done) {
   corpus.isRequestingUserAnAdminOnCorpus(req, requestingUser, dbConn, function(error, result, messages) {
     if (error) {
       return done(error, result, messages);
-    } 
+    }
 
     console.log(new Date() + " User " + requestingUser + " is admin and can modify permissions on " + dbConn.pouchname);
 
@@ -939,8 +940,8 @@ module.exports.addRoleToUser = function(req, done) {
       var userModificationResults = [];
 
       console.log(new Date() + " recieved promises back " + results.length)
-      console.log(new Date() + " req.body.users" , req.body.users)
-      
+      console.log(new Date() + " req.body.users", req.body.users)
+
       // results.forEach(function(result) {
       //   if (!result) {
       //     return;
@@ -959,23 +960,23 @@ module.exports.addRoleToUser = function(req, done) {
       //   }
       // });
       req.body.users.map(function(userPermis) {
-        if(userPermis.status === 200){
+        if (userPermis.status === 200) {
           done(null, req.body.users);
         }
       });
 
-       done({
+      done({
         status: req.body.users[0].status,
         error: "One or more of the add roles requsts failed. " + req.body.users[0].message
       }, req.body.users);
 
     });
-// .fail(function(error) {
-//       console.log(" returning fail.");
-//       error.status = error.status || req.body.users[0].status || 500;
-//       req.body.users[0].message = req.body.users[0].message || " There was a problem processing your request. Please notify us of this error 320343";
-//       return done(error, req.body.users);
-//     });
+    // .fail(function(error) {
+    //       console.log(" returning fail.");
+    //       error.status = error.status || req.body.users[0].status || 500;
+    //       req.body.users[0].message = req.body.users[0].message || " There was a problem processing your request. Please notify us of this error 320343";
+    //       return done(error, req.body.users);
+    //     });
   });
 };
 
@@ -1195,7 +1196,9 @@ var addCorpusToUser = function(error, username, newcorpusConnection, userPermiss
     if (userPermissionResult.after.length > 0) {
       if (indexOfNewCorpusInExistingCorpuses > -1) {
         userPermissionResult.status = 200;
-        userPermissionResult.message = 'Modified permission(s) to user, the user is already a member of this corpus team.';
+        userPermissionResult.message = 'User ' + user.username + ' now has ' +
+          userPermissionResult.after.join(" ") + " access to " +
+          newcorpusConnection.pouchname + ', the user was already a member of this corpus team.';
         return done(
           null, userPermissionResult, {
             message: userPermissionResult.message
@@ -1227,7 +1230,9 @@ var addCorpusToUser = function(error, username, newcorpusConnection, userPermiss
       if (error) {
         error.status = error.status || 505
         userPermissionResult.status = error.status;
-        userPermissionResult.message = "Modified permission(s) for " + username + " but we weren't able to add this corpus to their account. This is most likely a bug, please report it.";
+        userPermissionResult.message = 'User ' + user.username + ' now has ' +
+          userPermissionResult.after.join(" ") + " access to " +
+          newcorpusConnection.pouchname + ", but we weren't able to add this corpus to their account. This is most likely a bug, please report it.";
         return doneAddingCorpusToUser(
           error,
           userPermissionResult, {
@@ -1277,7 +1282,7 @@ var addCorpusToUser = function(error, username, newcorpusConnection, userPermiss
           ", mailconfig: " + (mail_config.mailConnection.auth.user !== ""));
 
         userPermissionResult.status = 200;
-        userPermissionResult.message = 'User ' + user.username + ' has ' +
+        userPermissionResult.message = 'User ' + user.username + ' now has ' +
           userPermissionResult.after.join(" ") + " access to " +
           newcorpusConnection.pouchname
         return doneAddingCorpusToUser(

--- a/lib/userauthentication.js
+++ b/lib/userauthentication.js
@@ -353,7 +353,7 @@ module.exports.registerNewUser = function(localOrNot, req, done) {
 
       if (dontCreateDBsForLearnXUsersBecauseThereAreTooManyOfThem &&
         (couchConnection.pouchname.indexOf("anonymouskartulispeechrecognition") > -1 ||
-          couchConnection.pouchname.indexOf(/anonymous[0-9]/) > -1)) {
+          couchConnection.pouchname.search(/anonymous[0-9]/) > -1)) {
         console.log(new Date() + "  delaying creation of the dbs for " + couchConnection.pouchname + " and " + activityCouchConnection.pouchname + " until they can actually use them.");
 
         emailWelcomeToTheUser(user);

--- a/lib/userauthentication.js
+++ b/lib/userauthentication.js
@@ -827,136 +827,155 @@ module.exports.addRoleToUser = function(req, done) {
   }
 
   if (!req || !req.body.users || req.body.users.length === 0 || !req.body.users[0].username) {
+    var placeholder = {
+      status: 412,
+      message: "This app has made an invalid request. Please notify its developer. missing: user(s) to modify"
+    };
     return done({
       status: 412,
       error: "Client didnt define the username to modify."
-    }, null, {
-      message: "This app has made an invalid request. Please notify its developer. missing: user(s) to modify"
+    }, placeholder, {
+      message: placeholder.message
     });
   }
 
   if ((!req.body.users[0].add || req.body.users[0].add.length < 1) && (!req.body.users[0].remove || req.body.users[0].remove.length < 1)) {
+    var placeholder = {
+      status: 412,
+      message: "This app has made an invalid request. Please notify its developer. missing: roles to add or remove"
+    };
     return done({
       status: 412,
       error: "Client didnt define the roles to add nor remove"
-    }, null, {
-      message: "This app has made an invalid request. Please notify its developer. missing: roles to add or remove"
+    }, placeholder, {
+      message: placeholder.message
     });
   }
 
   corpus.isRequestingUserAnAdminOnCorpus(req, requestingUser, dbConn, function(error, result, messages) {
     if (error) {
       return done(error, result, messages);
-    } else {
-      console.log(new Date() + " User " + requestingUser + " is admin and can modify permissions on " + dbConn.pouchname);
+    } 
 
-      var sanitizeRoles = function(role) {
-        if (role.indexOf("_") > -1) {
-          role = role.substring(role.lastSubstring("_"));
-        }
-        role = dbConn.pouchname + "_" + role;
-        return role;
-      };
+    console.log(new Date() + " User " + requestingUser + " is admin and can modify permissions on " + dbConn.pouchname);
 
-      // convert roles into corpus specific roles
-      req.body.users = req.body.users.map(function(userPermission) {
-        if (userPermission.add && typeof userPermission.add.map === "function") {
-          userPermission.add = userPermission.add.map(sanitizeRoles);
-        } else {
-          userPermission.add = [];
-        }
-        if (userPermission.remove && typeof userPermission.remove.map === "function") {
-          userPermission.remove = userPermission.remove.map(sanitizeRoles);
-        } else {
-          userPermission.remove = [];
-        }
-        return userPermission;
-      });
+    var sanitizeRoles = function(role) {
+      if (role.indexOf("_") > -1) {
+        role = role.substring(role.lastSubstring("_"));
+      }
+      role = dbConn.pouchname + "_" + role;
+      return role;
+    };
+
+    // convert roles into corpus specific roles
+    req.body.users = req.body.users.map(function(userPermission) {
+      if (userPermission.add && typeof userPermission.add.map === "function") {
+        userPermission.add = userPermission.add.map(sanitizeRoles);
+      } else {
+        userPermission.add = [];
+      }
+      if (userPermission.remove && typeof userPermission.remove.map === "function") {
+        userPermission.remove = userPermission.remove.map(sanitizeRoles);
+      } else {
+        userPermission.remove = [];
+      }
+      return userPermission;
+    });
 
 
-      var promises = [];
+    var promises = [];
+
+    var deferred = Q.defer();
+    promises.push(deferred.promise);
+    /*
+     * If they are admin, add the role to the user, then add the corpus to user if succesfull
+     */
+
+    for (var userIndex = 0; userIndex < req.body.users.length; userIndex++) {
+      var sameTempPasswordForAllTheirUsers = makeRandomPassword();
+
+      (function(userPermission) {
+
+        corpus_management.addRoleToUser(dbConn, req.body.users[0], function(error, resultOfAddedToCorpusPermissions, info) {
+
+          // return done({
+          //   status: 412,
+          //   error: "TODO"
+          // }, resultOfAddedToCorpusPermissions, {
+          //   message: "TODO after addRoleToUser"
+          // });
+
+          addCorpusToUser(error, userPermission.username, dbConn, resultOfAddedToCorpusPermissions, function(error, resultOfAddedToCorpusPermissions, info) {
+            console.log(" Bringing in mesages and status from successful user result.");
+            console.log(userPermission);
+            console.log(resultOfAddedToCorpusPermissions);
+            for (var attrib in resultOfAddedToCorpusPermissions) {
+              if (!resultOfAddedToCorpusPermissions.hasOwnProperty(attrib)) {
+                continue;
+              }
+              userPermission[attrib] = resultOfAddedToCorpusPermissions[attrib];
+            }
+            deferred.resolve("happy");
+          });
+        }, function(error, resultOfAddedToCorpusPermissions, info) {
+          console.log(" Bringing in mesages and status from failing user result.");
+          console.log(userPermission);
+          console.log(resultOfAddedToCorpusPermissions);
+          for (var attrib in resultOfAddedToCorpusPermissions) {
+            if (!resultOfAddedToCorpusPermissions.hasOwnProperty(attrib)) {
+              continue;
+            }
+            userPermission[attrib] = resultOfAddedToCorpusPermissions[attrib];
+          }
+          deferred.resolve("sad");
+        });
+
+      })(req.body.users[userIndex])
+    }
+
+
+
+    Q.allSettled(promises).then(function(results) {
       var userModificationResults = [];
 
-      var deferred = Q.defer();
-      promises.push(deferred.promise);
-      /*
-       * If they are admin, add the role to the user, then add the corpus to user if succesfull
-       */
-      var doneAddRoleToUser = done;
-      corpus_management.addRoleToUser(dbConn, req.body.users[0], function(error, resultOfAddedToCorpusPermissions, info) {
-
-        // return doneAddRoleToUser({
-        //   status: 412,
-        //   error: "TODO"
-        // }, resultOfAddedToCorpusPermissions, {
-        //   message: "TODO after addRoleToUser"
-        // });
-
-        addCorpusToUser(error, req.body.users[0].username, dbConn, resultOfAddedToCorpusPermissions, function() {
-          deffered.resolve("happy");
-        });
-      }, function() {
-        deffered.resolve("sad");
-      });
-
-
-      Q.allSettled(promises).then(function(results) {
-
-        return doneAddRoleToUser({
-          status: 412,
-          error: "TODO"
-        }, resultOfAddedToCorpusPermissions, {
-          message: "TODO after allSettled"
-        });
-
-        console.log(new Date() + " recieved promises back " + results.length)
-        results.forEach(function(result) {
-          if (!result) {
-            return;
-          }
-          if (result.state === "fulfilled") {
-            var value = result.value;
-            if (value.source && value.source.exception) {
-              userModificationResults = userModificationResults + " " + value.source.exception;
-            } else {
-              userModificationResults = userModificationResults + " " + "Success";
-            }
-          } else {
-            // not fulfilled,happens rarely
-            var reason = result.reason;
-            userModificationResults = userModificationResults + " " + reason;
-          }
-        });
-
-        if (userModificationResults.indexOf('Success') > -1) {
-          // At least one user was updated, probably all of htem...
-          returndata.users = req.body.users;
-          returndata.info = req.body.users.map(function(user) {
-            return message;
-          });
-          res.send(returndata);
-          return;
-
-        } else {
-          returndata.userFriendlyErrors = req.body.users.map(function(user) {
-            returndata.status = user.status;
-            res.status(user.status)
-            return message;
-          });
-          res.send(returndata);
-          return;
+      console.log(new Date() + " recieved promises back " + results.length)
+      console.log(new Date() + " req.body.users" , req.body.users)
+      
+      // results.forEach(function(result) {
+      //   if (!result) {
+      //     return;
+      //   }
+      //   if (result.state === "fulfilled") {
+      //     var value = result.value;
+      //     if (value.source && value.source.exception) {
+      //       userModificationResults = userModificationResults + " " + value.source.exception;
+      //     } else {
+      //       userModificationResults = userModificationResults + " " + "Success";
+      //     }
+      //   } else {
+      //     // not fulfilled,happens rarely
+      //     var reason = result.reason;
+      //     userModificationResults = userModificationResults + " " + reason;
+      //   }
+      // });
+      req.body.users.map(function(userPermis) {
+        if(userPermis.status === 200){
+          done(null, req.body.users);
         }
-
-      }).fail(function(error) {
-        error.status = error.status || 500;
-        return doneAddRoleToUser(error, resultDetails, {
-          message: "The server was unable to process your request. Please report this 2199."
-        });
       });
 
+       done({
+        status: req.body.users[0].status,
+        error: "One or more of the add roles requsts failed. " + req.body.users[0].message
+      }, req.body.users);
 
-
-    }
+    });
+// .fail(function(error) {
+//       console.log(" returning fail.");
+//       error.status = error.status || req.body.users[0].status || 500;
+//       req.body.users[0].message = req.body.users[0].message || " There was a problem processing your request. Please notify us of this error 320343";
+//       return done(error, req.body.users);
+//     });
   });
 };
 
@@ -1218,7 +1237,7 @@ var addCorpusToUser = function(error, username, newcorpusConnection, userPermiss
 
       // If the user was removed we can exit now
       if (userPermissionResult.after.length === 0) {
-        userPermissionResult.status = 400;
+        userPermissionResult.status = 200;
         userPermissionResult.message = "User " + user.username + " was removed from the " +
           newcorpusConnection.pouchname +
           " team.";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fielddb-auth",
-  "version": "2.44.22",
+  "version": "2.46.12",
   "description": "Authentication web services for FieldDB.",
   "homepage": "https://github.com/OpenSourceFieldlinguistics/FieldDB/issues/milestones?state=closed",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -38,11 +38,6 @@
     "uuid": "1.4.1"
   },
   "peerDependencies": {
-    "fielddb-api": "*",
-    "fielddb-web": "*",
-    "fielddb-audio": "*",
-    "fielddb-lexicon": "*",
-    "fielddb-spider": "*"
   },
   "devDependencies": {
     "grunt": "*",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bcrypt": "0.8.1",
     "cors": "*",
     "cradle": "0.6.6",
-    "diacritics": "1.0.0",
+    "diacritic": "0.0.2",
     "express": "3.5.2",
     "grunt-exec": "^0.4.6",
     "nano": "4.1.1",

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,17 @@
   <link href='//fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'/>
   <link href='css/highlight.default.css' media='screen' rel='stylesheet' type='text/css'/>
   <link href='css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-35422317-1', 'auto');
+    ga('set', 'page', 'api' + window.location.href.replace(window.location.protocol, "").replace(/^\//,""));
+    ga('send', 'pageview');
+
+  </script>
   <script type="text/javascript" src="lib/shred.bundle.js" /></script>  
   <script src='lib/jquery-1.8.0.min.js' type='text/javascript'></script>
   <script src='lib/jquery.slideto.min.js' type='text/javascript'></script>
@@ -72,7 +83,7 @@
 <div id="swagger-ui-container" class="swagger-ui-wrap">
 
 </div>
-
+ 
 </body>
 
 </html>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/routes/deprecated.js
+++ b/routes/deprecated.js
@@ -38,7 +38,7 @@ var addDeprecatedRoutes = function(app, node_config) {
     });
   });
   app.get('/login', function(req, res, next) {
-    res.send(); // {info: "Service is running normally."});
+    res.send({info: "Service is running normally."});
   });
 
   /**

--- a/routes/deprecated.js
+++ b/routes/deprecated.js
@@ -338,8 +338,8 @@ var addDeprecatedRoutes = function(app) {
       var currentlyProcessingUsername = req.body.users[0].username;
       authenticationfunctions.addRoleToUser(req, function(err, userPermissionSet) {
         console.log("Getting back the results of authenticationfunctions.addRoleToUser ");
-        console.log(err);
-        console.log(userPermissionSet);
+        // console.log(err);
+        // console.log(userPermissionSet);
 
         if (!userPermissionSet) {
           userPermissionSet = {
@@ -368,7 +368,7 @@ var addDeprecatedRoutes = function(app) {
           return userPermission.message;
         });
 
-        console.log(info);
+        // console.log(info);
 
         if (err) {
           res.status(err.status || 500);

--- a/routes/deprecated.js
+++ b/routes/deprecated.js
@@ -387,7 +387,7 @@ var addDeprecatedRoutes = function(app) {
           returndata.userFriendlyErrors = info;
 
         } else {
-          // returndata.roleadded = true;
+          returndata.roleadded = true;
           returndata.users = userPermissionSet;
           returndata.info = info;
           // returndata.userFriendlyErrors = ["Faking an error"];

--- a/start_service
+++ b/start_service
@@ -4,7 +4,6 @@ whoami
 echo "logs are in $PM2_HOME/logs"
 
 cd $FIELDDB_HOME/AuthenticationWebService
-bash switch_to_producti.sh 
 
 pm2 \
 start \

--- a/templates/private_corpus_template.js
+++ b/templates/private_corpus_template.js
@@ -24,7 +24,7 @@ module.exports = {
     "secretkey": ""
   },
   "publicCorpus": "Private",
-  "collection": "private_corpuses",
+  "collection": "private_corpora",
   "comments": [],
   "datumFields": [{
     "label": "judgement",

--- a/test/routes/deprecated.sh
+++ b/test/routes/deprecated.sh
@@ -128,7 +128,9 @@ echo "$TESTNAME"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
--d '{"username": "jenkins", "password": "phoneme"}' \
+-d '{"username": "jenkins", 
+"password": "phoneme",
+"appbrand": "learnx"}' \
 $SERVER/register `"
 echo ""
 echo "Response: $result";

--- a/test/routes/deprecated.sh
+++ b/test/routes/deprecated.sh
@@ -39,6 +39,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should return user details upon successful login"
+echo "$TESTNAME"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -64,6 +65,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should count down the password reset"
+echo "$TESTNAME"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -115,6 +117,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should refuse to register existing names"
+echo "$TESTNAME"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -141,6 +144,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should refuse to register short usernames"
+echo "$TESTNAME"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -196,6 +200,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should refuse to changepassword if the new password is missing"
+echo "$TESTNAME"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -223,6 +228,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should refuse to changepassword if the confirm password doesnt match"
+echo "$TESTNAME"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -250,6 +256,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should refuse forgotpassword if the user hasnt tried to login (ie doesnt know thier username)"
+echo "$TESTNAME"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -281,6 +288,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should accept forgotpassword"
+echo "$TESTNAME"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -314,6 +322,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should refuse to send a password reset if neither email nor username was provided"
+echo "$TESTNAME"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -341,6 +350,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should refuse to tell a corpusteam details if the username is not a valid user "
+echo "$TESTNAME"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -368,6 +378,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should refuse to tell a corpusteam details if the username is a valid user but on that team. eg: "
+echo "$TESTNAME"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -395,6 +406,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should reply with corpusteam details from the backbone app. "
+echo "$TESTNAME"
 echo " eg: "
 echo '{'
 echo '  "username": "jenkins",'
@@ -435,6 +447,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should accept corpusteam requests from the spreadsheet app. "
+echo "$TESTNAME"
 echo " eg: "
 echo '{'
 echo '  "username": "jenkins",'
@@ -473,6 +486,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should refuse to addroletouser if the user doesnt authenticate at the same time"
+echo "$TESTNAME"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -500,6 +514,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should refuse to addroletouser if the corpus is missing"
+echo "$TESTNAME"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -527,6 +542,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should refuse to addroletouser if the user(s) is missing"
+echo "$TESTNAME"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -559,6 +575,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should refuse to addroletouser if the user(s) roles to add or remove are missing"
+echo "$TESTNAME"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -590,6 +607,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should be able to remove all roles from user"
+echo "$TESTNAME"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -638,6 +656,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should call to addroletouser if the user(s) roles to add or remove are missing"
+echo "$TESTNAME"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -688,6 +707,7 @@ fi
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should refuse to add non-existant users to the corpus"
+echo "$TESTNAME"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -720,9 +740,9 @@ if [[ $result =~ userFriendlyErrors ]]
 fi 
 
 
-
 echo "-------------------------------------------------------------"
-# echo "It should accept roles to add and remove from one or or more users "
+TESTNAME="It should accept roles to add and remove from one or or more users "
+echo "$TESTNAME"
 # echo '{' 
 # echo '  "username": "jenkins",' 
 # echo '  "password": "phoneme",' 
@@ -768,7 +788,8 @@ echo "-------------------------------------------------------------"
 
 
 echo "-------------------------------------------------------------"
-# echo "It should accept addroletouser from the backbone app. eg: "
+TESTNAME="It should accept addroletouser from the backbone app. eg: "
+echo "$TESTNAME"
 # echo '  //Send username to limit the requests so only valid users can get a user list'
 # echo '  dataToPost.username = this.get("userPrivate").get("username");'
 # echo '  dataToPost.couchConnection = window.app.get("corpus").get("couchConnection");'
@@ -800,7 +821,8 @@ echo "-------------------------------------------------------------"
 
 
 echo "-------------------------------------------------------------"
-# echo "It should refuse newcorpus if the title is not specified"
+TESTNAME="It should refuse newcorpus if the title is not specified"
+echo "$TESTNAME"
 # TESTCOUNT=$[TESTCOUNT + 1]
 # result="`curl -kX POST \
 # -H "Content-Type: application/json" \
@@ -818,7 +840,8 @@ echo "-------------------------------------------------------------"
 # fi 
 
 echo "-------------------------------------------------------------"
-# echo "It should not complain if users tries to recreate a newcorpus"
+TESTNAME="It should not complain if users tries to recreate a newcorpus"
+echo "$TESTNAME"
 # TESTCOUNT=$[TESTCOUNT + 1]
 # result="`curl -kX POST \
 # -H "Content-Type: application/json" \
@@ -843,7 +866,8 @@ echo "-------------------------------------------------------------"
 # fi 
 
 echo "-------------------------------------------------------------"
-# echo "It should accept deprecated updateroles and run addroletouser (from the spreadsheet app eg)"
+TESTNAME="It should accept deprecated updateroles and run addroletouser (from the spreadsheet app eg)"
+echo "$TESTNAME"
 # echo 'file://angular_client/modules/spreadsheet/app/scripts/controllers/SpreadsheetController.js '
 # echo '      dataToPost.userRoleInfo = {};'
 # echo '      dataToPost.userRoleInfo.usernameToModify = userid;'
@@ -925,7 +949,8 @@ echo "-------------------------------------------------------------"
 
 
 echo "-------------------------------------------------------------"
-# echo "It should accept new updateroles (from the spreadsheet app eg)"
+TESTNAME="It should accept new updateroles (from the spreadsheet app eg)"
+echo "$TESTNAME"
 # echo '    '
 # TESTCOUNT=$[TESTCOUNT + 1]
 # result="`curl -kX POST \

--- a/test/routes/deprecated.sh
+++ b/test/routes/deprecated.sh
@@ -22,7 +22,7 @@ tput sgr0;
 
 TESTCOUNT=0;
 TESTFAILED=0;
-TESTSFAILEDSTRING="";
+TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
 TESTPASSED=0;
 TESTCOUNTEXPECTED=21;
 
@@ -37,32 +37,33 @@ else
   echo "Using $SERVER"
 fi
 
-echo ""
-echo "It should accept login"
+echo "-------------------------------------------------------------"
+TESTNAME="It should return user details upon successful login"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
 -d '{"username": "jenkins", "password": "phoneme"}' \
 $SERVER/login `"
 echo ""
-echo "Response: $result";
+echo "Response: $result" | grep -C 4 prefs;
 if [[ $result =~ userFriendlyErrors ]]
   then {
    TESTFAILED=$[TESTFAILED + 1]
-   TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should accept login"
+   TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
  }
 fi 
-if [[ $result =~ "\"lastname\": \"\"" ]]
+if [[ $result =~ "\"prefs\": " ]]
   then {
     echo "Details recieved, you can use this user object in your app settings for this user."
+    echo "   success";
   } else  {
    TESTFAILED=$[TESTFAILED + 1]
-   TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should return user details upon successful login"
+   TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
  }
 fi 
 
-echo ""
-echo "It should count down the password reset"
+echo "-------------------------------------------------------------"
+TESTNAME="It should count down the password reset"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -76,53 +77,44 @@ result="`curl -kX POST \
 -H "Content-Type: application/json" \
 -d '{"username": "jenkins", "password": "again"}' \
 $SERVER/login `"
-echo ""
+echo "$result"
 if [[ $result =~ "You have 2 more attempts"  ]]
   then {
-    echo "Response: $result";
+    echo "   success 2 more attempts";
   } else {
    TESTFAILED=$[TESTFAILED + 1]
-   TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should count down the password reset"
+   TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
  }
 fi
-
-
-echo ""
-echo "It should count down the password reset"
-TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
 -d '{"username": "jenkins", "password": "trying"}' \
 $SERVER/login `"
-echo ""
+# echo "$result"
 if [[ $result =~ "You have 1 more attempts"  ]]
   then {
-    echo "Response: $result";
+    echo "   success 1 more attempt";
   } else {
    TESTFAILED=$[TESTFAILED + 1]
-   TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should count down the password reset"
+   TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
  }
 fi
-
-echo ""
-echo "It should count down the password reset"
-TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
 -d '{"username": "jenkins", "password": "wrongpassword"}' \
 $SERVER/login `"
-echo ""
+echo "$result"
 if [[ $result =~ "You have tried to log in"  ]]
   then {
-    echo "Response: $result";
+    echo "   success warn user who have no email ";
   } else {
    TESTFAILED=$[TESTFAILED + 1]
-   TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should count down the password reset"
+   TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
  }
 fi
 
-echo ""
-echo "It should refuse to register existing names"
+echo "-------------------------------------------------------------"
+TESTNAME="It should refuse to register existing names"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -132,15 +124,23 @@ echo ""
 echo "Response: $result";
 if [[ $result =~ userFriendlyErrors ]]
   then {
-    echo " server refused, thats good."
-  } else {
-    TESTFAILED=$[TESTFAILED + 1]
-    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should refuse to register existing names"
-  }
+    echo "  success"
+    if [[ $result =~ "Username already exists, try a different username"  ]]
+      then {
+        echo "   server provided an informative message";
+      } else {
+       TESTFAILED=$[TESTFAILED + 1]
+       TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+     }
+   fi
+ } else {
+  TESTFAILED=$[TESTFAILED + 1]
+  TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+}
 fi 
 
-echo ""
-echo "It should refuse to register short usernames"
+echo "-------------------------------------------------------------"
+TESTNAME="It should refuse to register short usernames"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -150,31 +150,52 @@ echo ""
 echo "Response: $result";
 if [[ $result =~ userFriendlyErrors ]]
   then {
-    echo " server refused, thats good."
-  } else {
-    TESTFAILED=$[TESTFAILED + 1]
-    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should refuse to register short usernames"
-  }
+    echo " success"
+    if [[ $result =~ "Please choose a longer username"  ]]
+     then {
+       echo "   server provided an informative message";
+     } else {
+      TESTFAILED=$[TESTFAILED + 1]
+      TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+    }
+  fi
+} else {
+  TESTFAILED=$[TESTFAILED + 1]
+  TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+}
 fi 
 
-echo ""
-echo "It should accept changepassword"
+echo "-------------------------------------------------------------"
+TESTNAME"It should accept changepassword"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
 -d '{"username": "jenkins", "password": "phoneme", "newpassword": "phoneme", "confirmpassword": "phoneme"}' \
 $SERVER/changepassword `"
-echo ""
 if [[ $result =~ userFriendlyErrors ]]
   then {
-    echo "Response: $result";
+    echo "$result"
     TESTFAILED=$[TESTFAILED + 1]
-    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should accept changepassword"
-  }
+    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+  } else {
+    echo " success"
+    echo "Response: $result" | grep -C 4 prefs;
+    echo "Response: $result" | grep -C 4 password;
+    if [[ $result =~ "Your password has succesfully been updated"  ]]
+     then {
+       echo "   server provided an user details";
+       echo "   server provided an informative message";
+     } else {
+      TESTFAILED=$[TESTFAILED + 1]
+      TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+    }
+  fi
+}
 fi 
 
-echo ""
-echo "It should refuse to changepassword if the new password is missing"
+
+echo "-------------------------------------------------------------"
+TESTNAME="It should refuse to changepassword if the new password is missing"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -184,15 +205,24 @@ echo ""
 echo "Response: $result";
 if [[ $result =~ userFriendlyErrors ]]
   then {
-    echo " server refused, thats good."
-  } else {
-    TESTFAILED=$[TESTFAILED + 1]
-    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should refuse to changepassword if the new password is missing"
-  }
+    echo "   success"
+    if [[ $result =~ "Please provide your new password"  ]]
+     then {
+       echo "   server provided an informative message";
+     } else {
+      TESTFAILED=$[TESTFAILED + 1]
+      TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+    }
+  fi
+} else {
+  TESTFAILED=$[TESTFAILED + 1]
+  TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+}
 fi 
 
-echo ""
-echo "It should refuse to changepassword if the confirm password doesnt match"
+
+echo "-------------------------------------------------------------"
+TESTNAME="It should refuse to changepassword if the confirm password doesnt match"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -202,16 +232,29 @@ echo ""
 echo "Response: $result";
 if [[ $result =~ userFriendlyErrors ]]
   then {
-    echo " server refused, thats good."
-  } else {
-    TESTFAILED=$[TESTFAILED + 1]
-    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should refuse to changepassword if the confirm password doesnt match"
-  }
+    echo "   success"
+    if [[ $result =~ "New passwords do not match, please try again"  ]]
+     then {
+       echo "   server provided an informative message";
+     } else {
+      TESTFAILED=$[TESTFAILED + 1]
+      TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+    }
+  fi
+} else {
+  TESTFAILED=$[TESTFAILED + 1]
+  TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+}
 fi 
 
-echo ""
-echo "It should refuse forgotpassword if the user hasnt tried to login (ie doesnt know thier username)"
+
+echo "-------------------------------------------------------------"
+TESTNAME="It should refuse forgotpassword if the user hasnt tried to login (ie doesnt know thier username)"
 TESTCOUNT=$[TESTCOUNT + 1]
+result="`curl -kX POST \
+-H "Content-Type: application/json" \
+-d '{"username": "testinguserwithemail", "password": "test"}' \
+$SERVER/login `"
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
 -d '{"email": "myemail@example.com"}' \
@@ -220,16 +263,24 @@ echo ""
 echo "Response: $result";
 if [[ $result =~ userFriendlyErrors ]]
   then {  
-  echo "server refused, this is good."
+  echo "   success"
+  if [[ $result =~ "there are no users who have failed to login who have the email you provided"  ]]
+   then {
+     echo "   server provided an informative message";
+   } else {
+    TESTFAILED=$[TESTFAILED + 1]
+    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+  }
+fi
 } else {
   TESTFAILED=$[TESTFAILED + 1]
-  TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should refuse forgotpassword if the user hasnt tried to login (ie doesnt know thier username)"
+  TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
 }
 fi 
 
 
-echo ""
-echo "It should accept forgotpassword"
+echo "-------------------------------------------------------------"
+TESTNAME="It should accept forgotpassword"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -244,14 +295,25 @@ $SERVER/forgotpassword `"
 echo ""
 echo "Response: $result";
 if [[ $result =~ userFriendlyErrors ]]
-  then {
+  then {  
+  echo "   success"
+  if [[ $result =~ "Please report this 2893"  ]]
+   then {
+     echo "   server provided an informative message";
+   } else {
     TESTFAILED=$[TESTFAILED + 1]
-    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should accept forgotpassword"
+    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
   }
+fi
+} else {
+  TESTFAILED=$[TESTFAILED + 1]
+  TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+}
 fi 
 
-echo ""
-echo "It should refuse to send a password reset if neither email nor username was provided"
+
+echo "-------------------------------------------------------------"
+TESTNAME="It should refuse to send a password reset if neither email nor username was provided"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -261,35 +323,51 @@ echo ""
 echo "Response: $result";
 if [[ $result =~ userFriendlyErrors ]]
   then {
-    echo " server refused, thats good."
-  } else {
-    TESTFAILED=$[TESTFAILED + 1]
-    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should refuse to send a password reset if neither email nor username was provided"
-  }
+    echo "   success"
+    if [[ $result =~ "Please provide an email"  ]]
+     then {
+       echo "   server provided an informative message";
+     } else {
+      TESTFAILED=$[TESTFAILED + 1]
+      TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+    }
+  fi
+} else {
+  TESTFAILED=$[TESTFAILED + 1]
+  TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+}
 fi 
 
-echo ""
-echo "It should refuse to tell a corpusteam details if the username is not a valid user "
-echo ""
+
+echo "-------------------------------------------------------------"
+TESTNAME="It should refuse to tell a corpusteam details if the username is not a valid user "
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
--d '{"username": "testingspreadsheet",  "couchConnection": {"pouchname": "jenkins-firstcorpus"} }' \
+-d '{"username": "testingspreadshee",  "couchConnection": {"pouchname": "jenkins-firstcorpus"} }' \
 $SERVER/corpusteam `"
 echo ""
 echo "Response: $result";
 if [[ $result =~ userFriendlyErrors ]]
   then {
-    echo "server refused, this is good."
-  } else {
-    TESTFAILED=$[TESTFAILED + 1]
-    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should accept corpusteam from the spreadsheet app"
-  }
+    echo "   success"
+    if [[ $result =~ "Unauthorized, you are not a member of this corpus team"  ]]
+     then {
+       echo "   server provided an informative message";
+     } else {
+      TESTFAILED=$[TESTFAILED + 1]
+      TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+    }
+  fi
+} else {
+  TESTFAILED=$[TESTFAILED + 1]
+  TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+}
 fi 
 
-echo ""
-echo "It should refuse to tell a corpusteam details if the username is not a valid user and on that team. eg: "
-echo ""
+
+echo "-------------------------------------------------------------"
+TESTNAME="It should refuse to tell a corpusteam details if the username is a valid user but on that team. eg: "
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
@@ -299,247 +377,570 @@ echo ""
 echo "Response: $result";
 if [[ $result =~ userFriendlyErrors ]]
   then {
-    echo "server refused, this is good."
-  } else {
-    TESTFAILED=$[TESTFAILED + 1]
-    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should refuse to tell a corpusteam details if the username is not a valid user and on that team."
-  }
+    echo "   success"
+    if [[ $result =~ "Unauthorized, you are not a member of this corpus team"  ]]
+     then {
+       echo "   server provided an informative message";
+     } else {
+      TESTFAILED=$[TESTFAILED + 1]
+      TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+    }
+  fi
+} else {
+  TESTFAILED=$[TESTFAILED + 1]
+  TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+}
 fi 
 
-echo ""
-echo "It should accept corpusteam from the backbone app. eg: "
-echo '  //Send username to limit the requests so only valid users can get a user list'
-echo '  dataToPost.username = this.get("userPrivate").get("username");'
-echo '  dataToPost.couchConnection = window.app.get("corpus").get("couchConnection");'
+
+echo "-------------------------------------------------------------"
+TESTNAME="It should reply with corpusteam details from the backbone app. "
+echo " eg: "
+echo '{'
+echo '  "username": "jenkins",'
+echo '  "password": "phoneme",'
+echo '  "couchConnection": {'
+echo '    "pouchname": "jenkins-firstcorpus"'
+echo '  }'
+echo '}'
 echo ""
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
--d '{"username": "jenkins", "password": "phoneme", "couchConnection": {"pouchname": "jenkins-firstcorpus"} }' \
+-d '{"username": "jenkins", 
+"password": "phoneme", 
+"couchConnection": 
+{"pouchname": 
+"jenkins-firstcorpus"} }' \
 $SERVER/corpusteam `"
 echo ""
 if [[ $result =~ userFriendlyErrors ]]
   then {
     echo "Response: $result";
     TESTFAILED=$[TESTFAILED + 1]
-    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should reply with corpusteam details for backbone"
+    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
   } else {
     if [[ $result =~ readers ]]
       then {
         echo "Response: $result" | grep -C 4 readers;
-        echo " server replied with team details to a prototype-like request."
+        echo "   server replied with team details to a prototype-like request."
       } else {
         TESTFAILED=$[TESTFAILED + 1]
-        TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should reply with corpusteam details for backbone"
+        TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
       }
     fi 
   }
 fi 
 
-echo ""
-echo "It should accept corpusteam requests from the spreadsheet app. eg: "
-echo ' dataToPost.username = $rootScope.loginInfo.username;'
-echo ' dataToPost.password = $rootScope.loginInfo.password;'
-echo ' dataToPost.serverCode = $rootScope.serverCode;'
-echo ' dataToPost.authUrl = Servers.getServiceUrl($rootScope.serverCode, "auth");'
-echo ' dataToPost.pouchname = $rootScope.corpus.pouchname;'
+
+echo "-------------------------------------------------------------"
+TESTNAME="It should accept corpusteam requests from the spreadsheet app. "
+echo " eg: "
+echo '{'
+echo '  "username": "jenkins",'
+echo '  "password": "phoneme",'
+echo '  "serverCode": "localhost",'
+echo '  "pouchname": "jenkins-firstcorpus"'
+echo '}'
 echo ""
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
--d '{"username": "jenkins", "password": "phoneme", "serverCode": "localhost", "pouchname": "jenkins-firstcorpus"}' \
+-d '{"username": "jenkins", 
+"password": "phoneme", 
+"serverCode": "localhost", 
+"pouchname": "jenkins-firstcorpus"}' \
 $SERVER/corpusteam `"
 echo ""
 if [[ $result =~ userFriendlyErrors ]]
   then {
     echo "Response: $result";
     TESTFAILED=$[TESTFAILED + 1]
-    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should accept corpusteam from the spreadsheet app"
+    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
   } else {
     if [[ $result =~ readers ]]
       then {
         echo "Response: $result" | grep -C 4 readers;
-        echo " server replied with team details to a spreadsheet-like request"
+        echo "   server replied with team details to a spreadsheet-like request"
       } else {
         TESTFAILED=$[TESTFAILED + 1]
-        TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should reply with corpus team details"
+        TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
       }
     fi 
   }
 fi 
 
-echo ""
-echo "It should refuse to addroletouser if the corpus is missing"
+
+echo "-------------------------------------------------------------"
+TESTNAME="It should refuse to addroletouser if the user doesnt authenticate at the same time"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
--d '{"username": "jenkins", "password": "phoneme" }' \
+-d '{"username": "jenkins"}' \
 $SERVER/addroletouser `"
 echo ""
 echo "Response: $result";
 if [[ $result =~ userFriendlyErrors ]]
   then {
-    echo "sever refused, this is good."
+    echo "   success"
+    if [[ $result =~ "user credentials must be reqested from the user prior to running this request" ]]
+      then {
+        echo "   server replied an informative message"
+      } else {
+        TESTFAILED=$[TESTFAILED + 1]
+        TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+      }
+    fi 
   } else {
     TESTFAILED=$[TESTFAILED + 1]
-    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should refuse to addroletouser if the corpus is missing"
+    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
   }
 fi 
 
-echo ""
-echo "It should accept addroletouser from the backbone app. eg: "
-echo '  //Send username to limit the requests so only valid users can get a user list'
-echo '  dataToPost.username = this.get("userPrivate").get("username");'
-echo '  dataToPost.couchConnection = window.app.get("corpus").get("couchConnection");'
-echo ""
+
+echo "-------------------------------------------------------------"
+TESTNAME="It should refuse to addroletouser if the corpus is missing"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
--d '{"username": "jenkins", "password": "phoneme", "userToAddToRole": "testingprototype", "roles": ["reader","commenter"], "couchConnection": {"pouchname": "jenkins-firstcorpus"} }' \
+-d '{"username": "jenkins",
+"password": "phoneme" }' \
+$SERVER/addroletouser `"
+echo ""
+echo "Response: $result";
+if [[ $result =~ userFriendlyErrors ]]
+  then {
+    echo "   success"
+    if [[ $result =~ "the corpus to be modified must be included in the request" ]]
+      then {
+        echo "   server replied with an informative message"
+      } else {
+        TESTFAILED=$[TESTFAILED + 1]
+        TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+      }
+    fi 
+  } else {
+    TESTFAILED=$[TESTFAILED + 1]
+    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+  }
+fi 
+
+echo "-------------------------------------------------------------"
+TESTNAME="It should refuse to addroletouser if the user(s) is missing"
+TESTCOUNT=$[TESTCOUNT + 1]
+result="`curl -kX POST \
+-H "Content-Type: application/json" \
+-d '{"username": "jenkins", 
+"password": "phoneme", 
+"couchConnection": {
+  "pouchname":
+  "jenkins-firstcorpus"
+} }' \
+$SERVER/addroletouser `"
+echo ""
+echo "Response: $result";
+if [[ $result =~ userFriendlyErrors ]]
+  then {
+    echo "   success"
+    if [[ $result =~ "user(s) to modify must be included in this request" ]]
+      then {
+        echo "   server replied with an informative message"
+      } else {
+        TESTFAILED=$[TESTFAILED + 1]
+        TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+      }
+    fi 
+  } else {
+    TESTFAILED=$[TESTFAILED + 1]
+    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+  }
+fi 
+
+
+echo "-------------------------------------------------------------"
+TESTNAME="It should refuse to addroletouser if the user(s) roles to add or remove are missing"
+TESTCOUNT=$[TESTCOUNT + 1]
+result="`curl -kX POST \
+-H "Content-Type: application/json" \
+-d '{"username": "jenkins", "password": "phoneme",
+"users": [{
+  "username": "testingprototype"
+}],
+"couchConnection": {"pouchname": "jenkins-firstcorpus"} }' \
+$SERVER/addroletouser `"
+echo ""
+echo "Response: $result";
+if [[ $result =~ userFriendlyErrors ]]
+  then {
+    echo "   success"
+    if [[ $result =~ "roles to add or remove" ]]
+      then {
+        echo "   server replied with an informative message"
+      } else {
+        TESTFAILED=$[TESTFAILED + 1]
+        TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+      }
+    fi 
+  } else {
+    TESTFAILED=$[TESTFAILED + 1]
+    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+  }
+fi 
+
+
+echo "-------------------------------------------------------------"
+TESTNAME="It should be able to remove all roles from user"
+TESTCOUNT=$[TESTCOUNT + 1]
+result="`curl -kX POST \
+-H "Content-Type: application/json" \
+-d '{"username": "jenkins", "password": "phoneme",
+"users": [{
+  "username": "testingprototype",
+  "remove": ["all"]
+}],
+"couchConnection": {"pouchname": "jenkins-firstcorpus"} }' \
 $SERVER/addroletouser `"
 echo ""
 echo "Response: $result";
 if [[ $result =~ userFriendlyErrors ]]
   then {
     TESTFAILED=$[TESTFAILED + 1]
-    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should accept addroletouser from the backbone app"
+    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
   } else {
-    if [[ $result =~ "Added role(s) to user" ]]
+    echo "   success"
+    if [[ $result =~ "was removed from" ]]
       then {
-        echo "Response: $result" | grep -C 4 readers;
-        echo " server replied with addroletouser details to a prototype-like request."
+        echo "   server replied with an informative message"
+
+        echo " Checking if corpus was removed from the user"
+        result="`curl -kX POST \
+        -H "Content-Type: application/json" \
+        -d '{"username": "testingprototype", "password": "test"}' \
+        $SERVER/login `"
+        echo "Response: $result" | grep -C 4 pouchname;
+        if [[ $result =~ "\"pouchname\": \"jenkins-firstcorpus\"" ]]
+          then {
+            TESTFAILED=$[TESTFAILED + 1]
+            TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+          } else {
+            echo "  sever removed the corpus from this user too"
+          }
+        fi 
+
       } else {
         TESTFAILED=$[TESTFAILED + 1]
-        TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should reply with addroletouser team details for backbone"
+        TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
       }
     fi 
   }
 fi 
 
 
-echo ""
-echo "It should refuse newcorpus if the title is not specified"
+echo "-------------------------------------------------------------"
+TESTNAME="It should call to addroletouser if the user(s) roles to add or remove are missing"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
--d '{"username": "jenkins", "password": "phoneme"}' \
-$SERVER/newcorpus `"
+-d '{"username": "jenkins", "password": "phoneme",
+"users": [{
+  "username": "testingprototype",
+  "add": ["reader", "commenter"],
+  "remove": ["admin", "writer"]
+}],
+"couchConnection": {"pouchname": "jenkins-firstcorpus"} }' \
+$SERVER/addroletouser `"
 echo ""
 echo "Response: $result";
 if [[ $result =~ userFriendlyErrors ]]
   then {
-    echo "sever refused, this is good."
-  } else {
     TESTFAILED=$[TESTFAILED + 1]
-    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should refuse newcorpus if the title is not specified"
-  }
-fi 
-
-echo ""
-echo "It should not complain if users tries to recreate a newcorpus"
-TESTCOUNT=$[TESTCOUNT + 1]
-result="`curl -kX POST \
--H "Content-Type: application/json" \
--d '{"username": "jenkins", "password": "phoneme", "newCorpusName": "My new corpus title"}' \
-$SERVER/newcorpus `"
-echo ""
-echo "Response: $result";
-if [[ $result =~ userFriendlyErrors ]]
-  then {
-   echo "server replied with user friendly errors, which is okay"
-   } else {
-    if [[ $result =~ 302 ]]
+    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+  } else {
+    echo "   success"
+    if [[ $result =~ "has reader commenter access" ]]
       then {
-        echo "Response: $result" | grep -C 2 my_new_corpus_title;
-        echo " server replied with a 302 status saying it existed."
+        echo "   sever replied with updated role information"
+
+        echo " Checking if corpus was added to the user"
+        result="`curl -kX POST \
+        -H "Content-Type: application/json" \
+        -d '{"username": "testingprototype", 
+        "password": "test"}' \
+        $SERVER/login `"
+        echo "Response: $result" | grep -C 2 "jenkins-firstcorpus";
+        if [[ $result =~ "\"pouchname\": \"jenkins-firstcorpus\"" ]]
+          then {
+            echo "    sever added corpus to this user too"
+          } else {
+            TESTFAILED=$[TESTFAILED + 1]
+            TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+          }
+        fi 
+
       } else {
         TESTFAILED=$[TESTFAILED + 1]
-        TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should reply with a 302 status code"
+        TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
       }
     fi 
   }
 fi 
 
-echo ""
-echo "It should accept deprecated updateroles and run addroletouser (from the spreadsheet app eg)"
-echo 'file://angular_client/modules/spreadsheet/app/scripts/controllers/SpreadsheetController.js '
-echo '      dataToPost.userRoleInfo = {};'
-echo '      dataToPost.userRoleInfo.usernameToModify = userid;'
-echo '      dataToPost.userRoleInfo.pouchname = $rootScope.corpus.pouchname;'
-echo '      //dataToPost.userRoleInfo.removeUser = true;'
-echo '      switch (newUserRoles.role) {'
-# echo '      /*'
-# echo '            NOTE THESE ROLES are not accurate reflections of the db roles,'
-# echo '            they are a simplification which assumes the'
-# echo '            admin -> writer -> commenter -> reader type of system.'
-# echo ''
-# echo '            Infact some users (technical support or project coordinators) might be only admin,'
-# echo '            and some experiment participants might be only writers and'
-# echo '            cant see each others data.'
-# echo ''
-# echo '            Probably the clients wanted the spreadsheet roles to appear implicative since its more common.'
-# echo '            see https://github.com/OpenSourceFieldlinguistics/FieldDB/issues/1113'
-# echo '          */'
-# echo '      case "admin":'
-# echo '        newUserRoles.admin = true;'
-# echo '        newUserRoles.reader = true;'
-# echo '        newUserRoles.commenter = true;'
-# echo '        newUserRoles.writer = true;'
-# echo '        rolesString += " Admin";'
-# echo '        break;'
-# echo '      case "read_write":'
-# echo '        newUserRoles.admin = false;'
-# echo '        newUserRoles.reader = true;'
-# echo '        newUserRoles.commenter = true;'
-# echo '        newUserRoles.writer = true;'
-# echo '        rolesString += " Writer Reader";'
-# echo '        break;'
-# echo '      case "read_only":'
-# echo '        newUserRoles.admin = false;'
-# echo '        newUserRoles.reader = true;'
-# echo '        newUserRoles.commenter = false;'
-# echo '        newUserRoles.writer = false;'
-# echo '        rolesString += " Reader";'
-# echo '        break;'
-# echo '      case "read_comment_only":'
-# echo '        newUserRoles.admin = false;'
-# echo '        newUserRoles.reader = true;'
-# echo '        newUserRoles.commenter = true;'
-# echo '        newUserRoles.writer = false;'
-# echo '        rolesString += " Reader Commenter";'
-# echo '        break;'
-# echo '      case "write_only":'
-echo '        newUserRoles.admin = false;'
-echo '        newUserRoles.reader = false;'
-echo '        newUserRoles.commenter = true;'
-echo '        newUserRoles.writer = true;'
-echo '        rolesString += " Writer";'
-# echo '        break;'
-# echo '    }'
-echo ''
-echo '    newUserRoles.pouchname = $rootScope.corpus.pouchname;'
-echo ''
-echo '    var dataToPost = {};'
-echo '    dataToPost.username = $rootScope.user.username.trim();'
-echo '    dataToPost.password = $rootScope.loginInfo.password.trim();'
-echo '    dataToPost.serverCode = $rootScope.serverCode;'
-echo '    dataToPost.authUrl = Servers.getServiceUrl($rootScope.serverCode, "auth");'
-echo ''
-echo '    dataToPost.userRoleInfo = newUserRoles;'
-echo '    '
+
+echo "-------------------------------------------------------------"
+TESTNAME="It should refuse to add non-existant users to the corpus"
 TESTCOUNT=$[TESTCOUNT + 1]
 result="`curl -kX POST \
 -H "Content-Type: application/json" \
--d '{"username": "jenkins", "password": "phoneme", "serverCode": "localhost", "userRoleInfo": {"usernameToModify": "testingprototype", "pouchname": "jenkins-firstcorpus", "admin": false, "writer": true, "reader": true, "commenter": true }}' \
-$SERVER/updateroles `"
+-d '{"username": "jenkins", "password": "phoneme",
+"users": [{
+  "username": "userdoesntexist",
+  "add": ["reader", "commenter"],
+  "remove": ["admin", "writer"]
+}],
+"couchConnection": {"pouchname": "jenkins-firstcorpus"} }' \
+$SERVER/addroletouser `"
 echo ""
 echo "Response: $result";
 if [[ $result =~ userFriendlyErrors ]]
   then {
+    echo "   success"
+
+    if [[ $result =~ "username was unrecognized" ]]
+      then {
+        echo "   server provided an informative message"
+      } else {
+        TESTFAILED=$[TESTFAILED + 1]
+        TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+      }
+    fi 
+  } else {
     TESTFAILED=$[TESTFAILED + 1]
-    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : It should accept deprecated updateroles and run addroletouser"
+    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
   }
 fi 
+
+
+
+echo "-------------------------------------------------------------"
+# echo "It should accept roles to add and remove from one or or more users "
+# echo '{' 
+# echo '  "username": "jenkins",' 
+# echo '  "password": "phoneme",' 
+# echo '  "couchConnection": {' 
+# echo '    "pouchname": "jenkins-firstcorpus"' 
+# echo '  },' 
+# echo '  "users": [{' 
+# echo '    "username": "testingprototype",' 
+# echo '    "add": [' 
+# echo '      "reader",' 
+# echo '      "commenter"' 
+# echo '    ]' 
+# echo '  }, {' 
+# echo '    "username": "testingspreadsheet",' 
+# echo '    "add": [' 
+# echo '      "reader"' 
+# echo '    ],' 
+# echo '    "remove": [' 
+# echo '      "admin",' 
+# echo '      "writer"' 
+# echo '    ]' 
+# echo '  }]' 
+# echo '}' 
+# echo ''
+
+# -d '{"username": "jenkins", "password": "phoneme", "couchConnection": {"pouchname": "jenkins-firstcorpus", }, "users": [{"username": "testingprototype", "add": ["reader", "commenter"] }, {"username": "testingspreadsheet", "add": ["reader"], "remove": ["admin", "writer"] }] }' \
+# echo ""
+# TESTCOUNT=$[TESTCOUNT + 1]
+# result="`curl -kX POST \
+# -H "Content-Type: application/json" \
+# -d '{"username": "jenkins", "password": "phoneme"}' \
+# $SERVER/addroletouser `"
+# echo ""
+# echo "Response: $result";
+# if [[ $result =~ userFriendlyErrors ]]
+#   then {
+#     TESTFAILED=$[TESTFAILED + 1]
+#     TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+#   } else {
+#     echo " not failing yet"
+#   }
+# fi 
+
+
+echo "-------------------------------------------------------------"
+# echo "It should accept addroletouser from the backbone app. eg: "
+# echo '  //Send username to limit the requests so only valid users can get a user list'
+# echo '  dataToPost.username = this.get("userPrivate").get("username");'
+# echo '  dataToPost.couchConnection = window.app.get("corpus").get("couchConnection");'
+# echo ""
+# TESTCOUNT=$[TESTCOUNT + 1]
+# result="`curl -kX POST \
+# -H "Content-Type: application/json" \
+# -d '{"username": "jenkins", "password": "phoneme", "userToAddToRole": "testingprototype", "roles": ["reader","commenter"], "couchConnection": {"pouchname": "jenkins-firstcorpus"} }' \
+# $SERVER/addroletouser `"
+# echo ""
+# echo "Response: $result";
+# if [[ $result =~ userFriendlyErrors ]]
+#   then {
+#     TESTFAILED=$[TESTFAILED + 1]
+#     TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+#   } else {
+#     if [[ $result =~ "Added role(s) to user" ]]
+#       then {
+#         echo "Response: $result" | grep -C 4 readers;
+#         echo " server replied with addroletouser details to a prototype-like request."
+#       } else {
+#         TESTFAILED=$[TESTFAILED + 1]
+#         TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+#       }
+#     fi 
+#   }
+# fi 
+
+
+
+echo "-------------------------------------------------------------"
+# echo "It should refuse newcorpus if the title is not specified"
+# TESTCOUNT=$[TESTCOUNT + 1]
+# result="`curl -kX POST \
+# -H "Content-Type: application/json" \
+# -d '{"username": "jenkins", "password": "phoneme"}' \
+# $SERVER/newcorpus `"
+# echo ""
+# echo "Response: $result";
+# if [[ $result =~ userFriendlyErrors ]]
+#   then {
+#     echo "sever refused, this is good."
+#   } else {
+#     TESTFAILED=$[TESTFAILED + 1]
+#     TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+#   }
+# fi 
+
+echo "-------------------------------------------------------------"
+# echo "It should not complain if users tries to recreate a newcorpus"
+# TESTCOUNT=$[TESTCOUNT + 1]
+# result="`curl -kX POST \
+# -H "Content-Type: application/json" \
+# -d '{"username": "jenkins", "password": "phoneme", "newCorpusName": "My new corpus title"}' \
+# $SERVER/newcorpus `"
+# echo ""
+# echo "Response: $result";
+# if [[ $result =~ userFriendlyErrors ]]
+#   then {
+#    echo "server replied with user friendly errors, which is okay"
+#    } else {
+#     if [[ $result =~ 302 ]]
+#       then {
+#         echo "Response: $result" | grep -C 2 my_new_corpus_title;
+#         echo " server replied with a 302 status saying it existed."
+#       } else {
+#         TESTFAILED=$[TESTFAILED + 1]
+#         TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+#       }
+#     fi 
+#   }
+# fi 
+
+echo "-------------------------------------------------------------"
+# echo "It should accept deprecated updateroles and run addroletouser (from the spreadsheet app eg)"
+# echo 'file://angular_client/modules/spreadsheet/app/scripts/controllers/SpreadsheetController.js '
+# echo '      dataToPost.userRoleInfo = {};'
+# echo '      dataToPost.userRoleInfo.usernameToModify = userid;'
+# echo '      dataToPost.userRoleInfo.pouchname = $rootScope.corpus.pouchname;'
+# echo '      //dataToPost.userRoleInfo.removeUser = true;'
+# echo '      switch (newUserRoles.role) {'
+# # echo '      /*'
+# # echo '            NOTE THESE ROLES are not accurate reflections of the db roles,'
+# # echo '            they are a simplification which assumes the'
+# # echo '            admin -> writer -> commenter -> reader type of system.'
+# # echo ''
+# # echo '            Infact some users (technical support or project coordinators) might be only admin,'
+# # echo '            and some experiment participants might be only writers and'
+# # echo '            cant see each others data.'
+# # echo ''
+# # echo '            Probably the clients wanted the spreadsheet roles to appear implicative since its more common.'
+# # echo '            see https://github.com/OpenSourceFieldlinguistics/FieldDB/issues/1113'
+# # echo '          */'
+# # echo '      case "admin":'
+# # echo '        newUserRoles.admin = true;'
+# # echo '        newUserRoles.reader = true;'
+# # echo '        newUserRoles.commenter = true;'
+# # echo '        newUserRoles.writer = true;'
+# # echo '        rolesString += " Admin";'
+# # echo '        break;'
+# # echo '      case "read_write":'
+# # echo '        newUserRoles.admin = false;'
+# # echo '        newUserRoles.reader = true;'
+# # echo '        newUserRoles.commenter = true;'
+# # echo '        newUserRoles.writer = true;'
+# # echo '        rolesString += " Writer Reader";'
+# # echo '        break;'
+# # echo '      case "read_only":'
+# # echo '        newUserRoles.admin = false;'
+# # echo '        newUserRoles.reader = true;'
+# # echo '        newUserRoles.commenter = false;'
+# # echo '        newUserRoles.writer = false;'
+# # echo '        rolesString += " Reader";'
+# # echo '        break;'
+# # echo '      case "read_comment_only":'
+# # echo '        newUserRoles.admin = false;'
+# # echo '        newUserRoles.reader = true;'
+# # echo '        newUserRoles.commenter = true;'
+# # echo '        newUserRoles.writer = false;'
+# # echo '        rolesString += " Reader Commenter";'
+# # echo '        break;'
+# # echo '      case "write_only":'
+# echo '        newUserRoles.admin = false;'
+# echo '        newUserRoles.reader = false;'
+# echo '        newUserRoles.commenter = true;'
+# echo '        newUserRoles.writer = true;'
+# echo '        rolesString += " Writer";'
+# # echo '        break;'
+# # echo '    }'
+# echo ''
+# echo '    newUserRoles.pouchname = $rootScope.corpus.pouchname;'
+# echo ''
+# echo '    var dataToPost = {};'
+# echo '    dataToPost.username = $rootScope.user.username.trim();'
+# echo '    dataToPost.password = $rootScope.loginInfo.password.trim();'
+# echo '    dataToPost.serverCode = $rootScope.serverCode;'
+# echo '    dataToPost.authUrl = Servers.getServiceUrl($rootScope.serverCode, "auth");'
+# echo ''
+# echo '    dataToPost.userRoleInfo = newUserRoles;'
+# echo '    '
+# TESTCOUNT=$[TESTCOUNT + 1]
+# result="`curl -kX POST \
+# -H "Content-Type: application/json" \
+# -d '{"username": "jenkins", "password": "phoneme", "serverCode": "localhost", "userRoleInfo": {"usernameToModify": "testingprototype", "pouchname": "jenkins-firstcorpus", "admin": false, "writer": true, "reader": true, "commenter": true }}' \
+# $SERVER/updateroles `"
+# echo ""
+# echo "Response: $result";
+# if [[ $result =~ userFriendlyErrors ]]
+#   then {
+#     TESTFAILED=$[TESTFAILED + 1]
+#     TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+#   }
+# fi 
+
+
+echo "-------------------------------------------------------------"
+# echo "It should accept new updateroles (from the spreadsheet app eg)"
+# echo '    '
+# TESTCOUNT=$[TESTCOUNT + 1]
+# result="`curl -kX POST \
+# -H "Content-Type: application/json" \
+# -d '{"username": "jenkins", "password": "phoneme", "serverCode": "localhost", "pouchname": "jenkins-firstcorpus", "users": [{"username": "testingprototype", "add":["writer","commenter","reader"], "remove": ["admin"]} ] }' \
+# $SERVER/updateroles `"
+# echo ""
+# echo "Response: $result";
+# if [[ $result =~ userFriendlyErrors ]]
+#   then {
+#     TESTFAILED=$[TESTFAILED + 1]
+#     TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+#   }
+# fi 
+
 
 echo;
 echo;

--- a/test/routes/deprecated.sh
+++ b/test/routes/deprecated.sh
@@ -868,83 +868,109 @@ fi
 echo "-------------------------------------------------------------"
 TESTNAME="It should accept addroletouser from the backbone app. eg: "
 echo "$TESTNAME"
-# echo '  //Send username to limit the requests so only valid users can get a user list'
-# echo '  dataToPost.username = this.get("userPrivate").get("username");'
-# echo '  dataToPost.couchConnection = window.app.get("corpus").get("couchConnection");'
-# echo ""
-# TESTCOUNT=$[TESTCOUNT + 1]
-# result="`curl -kX POST \
-# -H "Content-Type: application/json" \
-# -d '{"username": "jenkins", "password": "phoneme", "userToAddToRole": "testingprototype", "roles": ["reader","commenter"], "couchConnection": {"pouchname": "jenkins-firstcorpus"} }' \
-# $SERVER/addroletouser `"
-# echo ""
-# echo "Response: $result";
-# if [[ $result =~ userFriendlyErrors ]]
-#   then {
-#     TESTFAILED=$[TESTFAILED + 1]
-#     TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
-#   } else {
-#     if [[ $result =~ "Added role(s) to user" ]]
-#       then {
-#         echo "Response: $result" | grep -C 4 readers;
-#         echo " server replied with addroletouser details to a prototype-like request."
-#       } else {
-#         TESTFAILED=$[TESTFAILED + 1]
-#         TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
-#       }
-#     fi 
-#   }
-# fi 
-
+result="`curl -kX POST \
+-H "Content-Type: application/json" \
+-d '{"username": "jenkins", "password": "phoneme",
+"users": [{
+  "username": "testingprototype",
+  "remove": ["all"]
+}],
+"couchConnection": {"pouchname": "jenkins-firstcorpus"} }' \
+$SERVER/addroletouser `"
+echo '  //Send username to limit the requests so only valid users can get a user list'
+echo '  dataToPost.username = this.get("userPrivate").get("username");'
+echo '  dataToPost.couchConnection = window.app.get("corpus").get("couchConnection");'
+echo ""
+TESTCOUNT=$[TESTCOUNT + 1]
+result="`curl -kX POST \
+-H "Content-Type: application/json" \
+-d '{"username": "jenkins", 
+"password": "phoneme", 
+"userToAddToRole": "testingprototype", 
+"roles": ["reader","commenter"], 
+"couchConnection": {
+  "pouchname": "jenkins-firstcorpus"
+} }' \
+$SERVER/addroletouser `"
+echo ""
+echo "Response: $result";
+if [[ $result =~ userFriendlyErrors ]]
+  then {
+    TESTFAILED=$[TESTFAILED + 1]
+    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+  } else {
+    echo "   success"
+    if [[ $result =~ "testingprototype now has reader commenter access to jenkins-firstcorpus" ]]
+      then {
+        echo "Response: $result" | grep -C 4 readers;
+        echo "    server replied with informative info"
+      } else {
+        TESTFAILED=$[TESTFAILED + 1]
+        TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+      }
+    fi 
+  }
+fi 
 
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should refuse newcorpus if the title is not specified"
 echo "$TESTNAME"
-# TESTCOUNT=$[TESTCOUNT + 1]
-# result="`curl -kX POST \
-# -H "Content-Type: application/json" \
-# -d '{"username": "jenkins", "password": "phoneme"}' \
-# $SERVER/newcorpus `"
-# echo ""
-# echo "Response: $result";
-# if [[ $result =~ userFriendlyErrors ]]
-#   then {
-#     echo "sever refused, this is good."
-#   } else {
-#     TESTFAILED=$[TESTFAILED + 1]
-#     TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
-#   }
-# fi 
+TESTCOUNT=$[TESTCOUNT + 1]
+result="`curl -kX POST \
+-H "Content-Type: application/json" \
+-d '{"username": "jenkins", "password": "phoneme"}' \
+$SERVER/newcorpus `"
+echo ""
+echo "Response: $result";
+if [[ $result =~ userFriendlyErrors ]]
+  then {
+    echo "   success"
+    if [[ $result =~ "missing: newCorpusName" ]]
+      then {
+        echo "Response: $result" | grep -C 4 readers;
+        echo "    server replied with informative info"
+      } else {
+        TESTFAILED=$[TESTFAILED + 1]
+        TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+      }
+    fi 
+  } else {
+    TESTFAILED=$[TESTFAILED + 1]
+    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+  }
+fi 
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should not complain if users tries to recreate a newcorpus"
 echo "$TESTNAME"
-# TESTCOUNT=$[TESTCOUNT + 1]
-# result="`curl -kX POST \
-# -H "Content-Type: application/json" \
-# -d '{"username": "jenkins", "password": "phoneme", "newCorpusName": "My new corpus title"}' \
-# $SERVER/newcorpus `"
-# echo ""
-# echo "Response: $result";
-# if [[ $result =~ userFriendlyErrors ]]
-#   then {
-#    echo "server replied with user friendly errors, which is okay"
-#    } else {
-#     if [[ $result =~ 302 ]]
-#       then {
-#         echo "Response: $result" | grep -C 2 my_new_corpus_title;
-#         echo " server replied with a 302 status saying it existed."
-#       } else {
-#         TESTFAILED=$[TESTFAILED + 1]
-#         TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
-#       }
-#     fi 
-#   }
-# fi 
+TESTCOUNT=$[TESTCOUNT + 1]
+result="`curl -kX POST \
+-H "Content-Type: application/json" \
+-d '{"username": "jenkins", 
+"password": "phoneme", 
+"newCorpusName": "My new corpus title"}' \
+$SERVER/newcorpus `"
+echo ""
+echo "Response: $result";
+if [[ $result =~ userFriendlyErrors ]]
+  then {
+   echo "   success"
+ } else {
+  if [[ $result =~ "already exists, no need to create it" ]]
+    then {
+      echo "Response: $result" | grep -C 2 my_new_corpus_title;
+      echo "    server replied with a 302 status saying it existed."
+    } else {
+      TESTFAILED=$[TESTFAILED + 1]
+      TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+    }
+  fi 
+}
+fi 
 
 echo "-------------------------------------------------------------"
-TESTNAME="It should accept deprecated updateroles and run addroletouser (from the spreadsheet app eg)"
+TESTNAME="It should accept deprecated updateroles and run addroletouser (from the spreadsheet app)"
 echo "$TESTNAME"
 # echo 'file://angular_client/modules/spreadsheet/app/scripts/controllers/SpreadsheetController.js '
 # echo '      dataToPost.userRoleInfo = {};'
@@ -1011,38 +1037,87 @@ echo "$TESTNAME"
 # echo ''
 # echo '    dataToPost.userRoleInfo = newUserRoles;'
 # echo '    '
-# TESTCOUNT=$[TESTCOUNT + 1]
-# result="`curl -kX POST \
-# -H "Content-Type: application/json" \
-# -d '{"username": "jenkins", "password": "phoneme", "serverCode": "localhost", "userRoleInfo": {"usernameToModify": "testingprototype", "pouchname": "jenkins-firstcorpus", "admin": false, "writer": true, "reader": true, "commenter": true }}' \
-# $SERVER/updateroles `"
-# echo ""
-# echo "Response: $result";
-# if [[ $result =~ userFriendlyErrors ]]
-#   then {
-#     TESTFAILED=$[TESTFAILED + 1]
-#     TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
-#   }
-# fi 
+TESTCOUNT=$[TESTCOUNT + 1]
+result="`curl -kX POST \
+-H "Content-Type: application/json" \
+-d '{"username": "jenkins", 
+"password": "phoneme", 
+"serverCode": "localhost", 
+"userRoleInfo": {
+  "usernameToModify": "testingprototype", 
+  "pouchname": "jenkins-firstcorpus", 
+  "admin": false, 
+  "writer": true, 
+  "reader": true, 
+  "commenter": true 
+}}' \
+$SERVER/updateroles `"
+echo ""
+echo "Response: $result";
+if [[ $result =~ userFriendlyErrors ]]
+  then {
+    TESTFAILED=$[TESTFAILED + 1]
+    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+  } else {
+    echo "   success"
+    if [[ $result =~ "has reader commenter writer access" ]]
+      then {
+        echo "Response: $result" | grep -C 3 after;
+        echo "    server replied with informative info"
+      } else {
+        TESTFAILED=$[TESTFAILED + 1]
+        TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+      }
+    fi 
+  }
+fi 
 
 
 echo "-------------------------------------------------------------"
 TESTNAME="It should accept new updateroles (from the spreadsheet app eg)"
 echo "$TESTNAME"
-# echo '    '
-# TESTCOUNT=$[TESTCOUNT + 1]
-# result="`curl -kX POST \
-# -H "Content-Type: application/json" \
-# -d '{"username": "jenkins", "password": "phoneme", "serverCode": "localhost", "pouchname": "jenkins-firstcorpus", "users": [{"username": "testingprototype", "add":["writer","commenter","reader"], "remove": ["admin"]} ] }' \
-# $SERVER/updateroles `"
-# echo ""
-# echo "Response: $result";
-# if [[ $result =~ userFriendlyErrors ]]
-#   then {
-#     TESTFAILED=$[TESTFAILED + 1]
-#     TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
-#   }
-# fi 
+result="`curl -kX POST \
+-H "Content-Type: application/json" \
+-d '{"username": "jenkins", "password": "phoneme",
+"users": [{
+  "username": "testingspreadsheet",
+  "remove": ["all"]
+}],
+"couchConnection": {"pouchname": "jenkins-firstcorpus"} }' \
+$SERVER/addroletouser `"
+echo '    '
+TESTCOUNT=$[TESTCOUNT + 1]
+result="`curl -kX POST \
+-H "Content-Type: application/json" \
+-d '{"username": "jenkins", 
+"password": "phoneme", 
+"serverCode": "localhost", 
+"pouchname": "jenkins-firstcorpus", 
+"users": [{
+  "username": "testingspreadsheet", 
+  "add":["writer","commenter","reader"], 
+  "remove": ["admin"]
+} ] }' \
+$SERVER/updateroles `"
+echo ""
+echo "Response: $result";
+if [[ $result =~ userFriendlyErrors ]]
+  then {
+    TESTFAILED=$[TESTFAILED + 1]
+    TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+  } else {
+    echo "   success"
+    if [[ $result =~ "testingspreadsheet now has writer commenter reader access" ]]
+      then {
+        echo "Response: $result" | grep -C 3 after;
+        echo "    server replied with informative info"
+      } else {
+        TESTFAILED=$[TESTFAILED + 1]
+        TESTSFAILEDSTRING="$TESTSFAILEDSTRING : $TESTNAME"
+      }
+    fi 
+  }
+fi 
 
 
 echo;


### PR DESCRIPTION
The first permissions route `addroletouser` let the prototype add multiple roles to one user #5 , added the corpus to their list of corpora in their user doc #6 , and emailed the user that they had access #8 . in the spreadsheet additions #14 #15 #16 #17 #18 #19 #20 #21 #22 #23  we wanted to add another route `updateroles` was added that made it possible to update the roles (including remove a user, which wasnt possible before), but it didn't let the user know if they had access to a new corpus, and it didn't put the corpus in the user's list of corpora, it also didn't return any useful information to the client side. at the time we thought this was okay because we really needed to release. some of the old functionality wasnt critical because the spreadsheet didn't use the user's doc, instead it contacted only the corpus server. it could find out which corpora they could access using their _session token, which on one hand, was always up-to-date, but on the other hand, it has started to cause more server load since each time the user logs in we have to do 1 request per corpus to get the corpus title and description to show to them, which caused the db to index the entire corpus, including other things like their lexicon... which is not trivial for a larger corpus. we would like to return to maintaining an up-to-date list of corpora in the user doc to reduce server load. 

The goal of this addition
* make an api we actually like and think will be useful
* be backward compatible with the data recieved from both `updateroles` and `addroletouser`
* make sure a user receives an email (if they provided an email) the first time they are given access to a new corpus
* make it easy to make a GUI for field methods instructors to add their students to a corpus in one batch process
* while this functionality is in the deprecated API, it should still be possible to move to a normal restful api naming convention in the new architecture eg POST /v2/corpus/:corpusidentifier/users

Input example:
```json
{
  "username": "jenkins",
  "password": "askjenkinstoreauthenticatebeforerunningthisrequest",
  "users": [{
    "username": "testingspreadsheet",
    "add": ["reader", "exporter"],
    "remove": ["admin", "writer"]
  }, {
    "username": "testingprototype",
    "add": ["writer"]
  }],
  "couchConnection": {
    "pouchname": "jenkins-firstcorpus"
  }
}
```
Reply:
```json
{
  "users": [
    {
      "username": "testingspreadsheet",
      "add": [
        "jenkins-firstcorpus_reader",
        "jenkins-firstcorpus_exporter"
      ],
      "remove": [
        "jenkins-firstcorpus_admin",
        "jenkins-firstcorpus_writer"
      ],
      "before": [],
      "after": [
        "reader",
        "exporter"
      ],
      "status": 200,
      "message": "User testingspreadsheet now has reader exporter access to jenkins-firstcorpus"
    },
    {
      "username": "testingprototype",
      "add": [
        "jenkins-firstcorpus_writer"
      ],
      "remove": [],
      "before": [],
      "after": [
        "writer"
      ],
      "status": 200,
      "message": "User testingprototype now has writer access to jenkins-firstcorpus"
    }
  ],
  "info": [
    "User testingspreadsheet now has reader exporter access to jenkins-firstcorpus",
    "User testingprototype now has writer access to jenkins-firstcorpus"
  ]
}
```


Sample test output:
```bash
$ npm test

> fielddb-auth@2.44.22 test /Users/username/fielddbhome/AuthenticationWebService
> grunt test

Running "nodeunit:files" (nodeunit) task
Testing fielddb-auth_test.js.....OK
>> 6 assertions passed (4ms)

Running "exec:curl_tests" (exec) task
=============================================================
  Running CURL tests for deprecated routes
=============================================================

Using https://localhost:3183
-------------------------------------------------------------
It should return user details upon successful login

    "authUrl": "https://localhost:3183",
    "description": "",
    "subtitle": "",
    "dataLists": [],
    "prefs": {
      "skin": "user/skins/weaving.jpg",
      "numVisibleDatum": 2,
      "transparentDashboard": "false",
      "alwaysRandomizeSkin": "true",
Details recieved, you can use this user object in your app settings for this user.
   success
-------------------------------------------------------------
It should count down the password reset
{
  "status": 401,
  "userFriendlyErrors": [
    "Username or password is invalid. Please try again. You have 2 more attempts before a temporary password will be emailed to your registration email (if you provided one)."
  ]
}
   success 2 more attempts
   success 1 more attempt
{
  "status": 401,
  "userFriendlyErrors": [
    "You have tried to log in too many times and you dont seem to have a valid email so we cant send you a temporary password."
  ]
}
   success warn user who have no email
-------------------------------------------------------------
It should refuse to register existing names

Response: {
  "userFriendlyErrors": [
    "Username already exists, try a different username."
  ]
}
  success
   server provided an informative message
-------------------------------------------------------------
It should refuse to register short usernames

Response: {
  "status": 412,
  "userFriendlyErrors": [
    "Please choose a longer username `ba` is too short."
  ]
}
 success
   server provided an informative message
-------------------------------------------------------------
It should accept changepassword
 success
    "authUrl": "https://localhost:3183",
    "description": "",
    "subtitle": "",
    "dataLists": [],
    "prefs": {
      "skin": "user/skins/weaving.jpg",
      "numVisibleDatum": 2,
      "transparentDashboard": "false",
      "alwaysRandomizeSkin": "true",
   server provided an user details
      ]
    }
  },
  "info": [
    "Your password has succesfully been updated."
  ]
}
   server provided an informative message
-------------------------------------------------------------
It should refuse to changepassword if the new password is missing

Response: {
  "status": 412,
  "userFriendlyErrors": [
    "Please provide your new password"
  ]
}
   success
   server provided an informative message
-------------------------------------------------------------
It should refuse to changepassword if the confirm password doesnt match

Response: {
  "status": 406,
  "userFriendlyErrors": [
    "New passwords do not match, please try again."
  ]
}
   success
   server provided an informative message
-------------------------------------------------------------
It should refuse forgotpassword if the user hasnt tried to login (ie doesnt know thier username)
100  6587  100  6531  100    56  5597 --:--:-- --:--:-- --:--:-- 55820

Response: {
  "status": 401,
  "userFriendlyErrors": [
    "Sorry, there are no users who have failed to login who have the email you provided myemail@example.com. You cannot request a temporary password until you have at least tried to login once with your correct username. If you are not able to guess your username please contact us for assistance."
  ]
}
   success
   server provided an informative message
-------------------------------------------------------------
It should accept forgotpassword (and fail on the last step if on a dev server since it has no credentials to send emails)
 prep: try to login with wrong password


Response: {
  "status": 500,
  "userFriendlyErrors": [
    " The server was unable to send you an email, your password has not been reset. Please report this 2893"
  ]
}
   success
   server provided an informative message
-------------------------------------------------------------
It should refuse to send a password reset if neither email nor username was provided

Response: {
  "status": 412,
  "userFriendlyErrors": [
    "Please provide an email."
  ]
}
   success
   server provided an informative message
-------------------------------------------------------------
It should refuse to tell a corpusteam details if the username is not a valid user

Response: {
  "status": 401,
  "userFriendlyErrors": [
    "Unauthorized, you are not a member of this corpus team."
  ]
}
   success
   server provided an informative message
-------------------------------------------------------------
It should refuse to tell a corpusteam details if the username is a valid user but on that team. eg:
 prep: remove user if currently on the team

Response: {
  "status": 401,
  "userFriendlyErrors": [
    "Unauthorized, you are not a member of this corpus team."
  ]
}
   success
   server provided an informative message
-------------------------------------------------------------
It should accept corpusteam requests from the backbone app.
 eg:
       {
         "username": "jenkins",
         "password": "phoneme",
         "couchConnection": {
           "pouchname": "jenkins-firstcorpus"
         }
       }


        "username": "jenkins",
        "gravatar": "8fb9f9c10f956f74ab9d67863d4a57fc"
      }
    ],
    "readers": [
      {
        "username": "jenkins",
        "gravatar": "8fb9f9c10f956f74ab9d67863d4a57fc"
      },
   server replied with team details to a prototype-like request.
-------------------------------------------------------------
It should accept corpusteam requests from the spreadsheet app.
 eg:
      {
        "username": "jenkins",
        "password": "phoneme",
        "serverCode": "localhost",
        "pouchname": "jenkins-firstcorpus"
      }


        "username": "jenkins",
        "gravatar": "8fb9f9c10f956f74ab9d67863d4a57fc"
      }
    ],
    "readers": [
      {
        "username": "jenkins",
        "gravatar": "8fb9f9c10f956f74ab9d67863d4a57fc"
      },
   server replied with team details to a spreadsheet-like request
-------------------------------------------------------------
It should refuse to addroletouser if the user doesnt authenticate at the same time
  0

Response: {
  "userFriendlyErrors": [
    "This app has made an invalid request. Please notify its developer. info: user credentials must be reqested from the user prior to running this request"
  ]
}
   success
   server replied an informative message
-------------------------------------------------------------
It should refuse to addroletouser if the corpus is missing

Response: {
  "userFriendlyErrors": [
    "This app has made an invalid request. Please notify its developer. info: the corpus to be modified must be included in the request"
  ]
}
   success
   server replied with an informative message
-------------------------------------------------------------
It should refuse to addroletouser if the user(s) to modify are missing

Response: {
  "userFriendlyErrors": [
    "This app has made an invalid request. Please notify its developer. info: user(s) to modify must be included in this request"
  ]
}
   success
   server replied with an informative message
-------------------------------------------------------------
It should refuse to addroletouser if the roles to add and/or remove are missing
100   308  100   155  100   153   1240   1224 --:--:--- --:--:--  1240

Response: {
  "status": 412,
  "userFriendlyErrors": [
    "This app has made an invalid request. Please notify its developer. missing: roles to add or remove"
  ]
}
   success
   server replied with an informative message
-------------------------------------------------------------
It should be able to remove all roles from a user

Response: {
  "users": [
    {
      "username": "testingprototype",
      "remove": [
        "jenkins-firstcorpus_all"
      ],
      "add": [],
      "before": [
        "reader",
        "commenter"
      ],
      "after": [],
      "status": 200,
      "message": "User testingprototype was removed from the jenkins-firstcorpus team."
    }
  ],
  "info": [
    "User testingprototype was removed from the jenkins-firstcorpus team."
  ]
}
   success
   server replied with an informative message
   Checking if corpus was removed from the user
      {
        "protocol": "https://",
        "domain": "corpus.lingsync.org",
        "port": "",
        "pouchname": "testingprototype-firstcorpus",
        "path": "",
        "authUrl": "https://auth.lingsync.org",
        "userFriendlyServerName": "LingSync.org"
      }
--
--
    "activityCouchConnection": {
      "protocol": "https://",
      "domain": "corpus.lingsync.org",
      "port": "",
      "pouchname": "testingprototype-activity_feed",
      "path": "",
      "authUrl": "https://auth.lingsync.org",
      "userFriendlyServerName": "LingSync.org"
    },
--
--
      "couchConnection": {
        "protocol": "https://",
        "domain": "corpus.lingsync.org",
        "port": "",
        "pouchname": "testingprototype-firstcorpus",
        "path": "",
        "authUrl": "https://auth.lingsync.org",
        "userFriendlyServerName": "LingSync.org"
      }
    sever made sure the corpus was removed in the user too
-------------------------------------------------------------
It should be able to add and remove roles in the same request

Response: {
  "users": [
    {
      "username": "testingprototype",
      "add": [
        "jenkins-firstcorpus_reader",
        "jenkins-firstcorpus_commenter"
      ],
      "remove": [
        "jenkins-firstcorpus_admin",
        "jenkins-firstcorpus_writer"
      ],
      "before": [],
      "after": [
        "reader",
        "commenter"
      ],
      "status": 200,
      "message": "User testingprototype now has reader commenter access to jenkins-firstcorpus"
    }
  ],
  "info": [
    "User testingprototype now has reader commenter access to jenkins-firstcorpus"
  ]
}
   success
   sever replied with updated role information
   Checking if corpus was added to the user
      },
      {
        "pouchname": "jenkins-firstcorpus",
        "protocol": "https://",
        "domain": "corpus.lingsync.org",
    sever made sure the corpus was listed in this user too
-------------------------------------------------------------
It should refuse to add non-existant users to the corpus

Response: {
  "status": 404,
  "userFriendlyErrors": [
    "You can't add userdoesntexist to this corpus, their username was unrecognized. User not found."
  ]
}
   success
   server provided an informative message
-------------------------------------------------------------
It should accept roles to add and remove from one or or more users
 prep: remove first user
 prep: remove other user
{
  "username": "jenkins",
  "password": "phoneme",
  "couchConnection": {
    "pouchname": "jenkins-firstcorpus"
  },
  "users": [{
    "username": "testingspreadsheet",
    "add": [
      "reader",
      "exporter"
    ],
    "remove": [
      "admin",
      "writer"
    ]
  }, {
    "username": "testingprototype",
    "add": [
      "writer"
    ]
  }]
}



Response: {
  "users": [
    {
      "username": "testingspreadsheet",
      "add": [
        "jenkins-firstcorpus_reader",
        "jenkins-firstcorpus_exporter"
      ],
      "remove": [
        "jenkins-firstcorpus_admin",
        "jenkins-firstcorpus_writer"
      ],
      "before": [],
      "after": [
        "reader",
        "exporter"
      ],
      "status": 200,
      "message": "User testingspreadsheet now has reader exporter access to jenkins-firstcorpus"
    },
    {
      "username": "testingprototype",
      "add": [
        "jenkins-firstcorpus_writer"
      ],
      "remove": [],
      "before": [],
      "after": [
        "writer"
      ],
      "status": 200,
      "message": "User testingprototype now has writer access to jenkins-firstcorpus"
    }
  ],
  "info": [
    "User testingspreadsheet now has reader exporter access to jenkins-firstcorpus",
    "User testingprototype now has writer access to jenkins-firstcorpus"
  ]
}
   success
   sever replied with updated role information
 Checking if corpus was added to the first user
      },
      {
        "pouchname": "jenkins-firstcorpus",
        "protocol": "https://",
        "domain": "corpus.lingsync.org",
    sever added corpus to the first user too
 Checking if corpus was added to the second user
      },
      {
        "pouchname": "jenkins-firstcorpus",
        "protocol": "https://",
        "domain": "corpus.lingsync.org",
    sever added corpus to the second user too
-------------------------------------------------------------
It should accept addroletouser from the backbone app. eg:
   {
      "username": "jenkins",
      "password": "phoneme",
      "userToAddToRole": "testingprototype",
      "roles": ["reader", "commenter"],
      "couchConnection": {
        "pouchname": "jenkins-firstcorpus"
      }
    }
 prep: remove the user

Response: {
  "users": [
    {
      "username": "testingprototype",
      "remove": [],
      "add": [
        "jenkins-firstcorpus_reader",
        "jenkins-firstcorpus_commenter"
      ],
      "before": [],
      "after": [
        "reader",
        "commenter"
      ],
      "status": 200,
      "message": "User testingprototype now has reader commenter access to jenkins-firstcorpus"
    }
  ],
  "info": [
    "User testingprototype now has reader commenter access to jenkins-firstcorpus"
  ]
}
   success
    server replied with informative info
-------------------------------------------------------------
It should refuse newcorpus if the title is not specified
100   192  100   146  100    46   1162    366 --:--:-- --:--:-- --:--:--  1158

Response: {
  "status": 412,
  "userFriendlyErrors": [
    "This app has made an invalid request. Please notify its developer. missing: newCorpusName"
  ]
}
   success
    server replied with informative info
-------------------------------------------------------------
It should not complain if users tries to recreate a newcorpus

Response: {
  "corpusadded": true,
  "info": [
    "User details saved."
  ],
  "status": 302,
  "userFriendlyErrors": [
    "Your corpus jenkins-my_new_corpus_title already exists, no need to create it."
  ]
}
   success
-------------------------------------------------------------
It should accept deprecated updateroles from the spreadsheet app  eg:
    {
      "username": "jenkins",
      "password": "phoneme",
      "serverCode": "localhost",
      "userRoleInfo": {
        "usernameToModify": "testingspreadsheet",
        "pouchname": "jenkins-firstcorpus",
        "admin": false,
        "writer": true,
        "reader": true,
        "commenter": true
      }
     }
 prep: remove the user
|
Response: {
  "users": [
    {
      "username": "testingspreadsheet",
      "remove": [],
      "add": [
        "jenkins-firstcorpus_writer",
        "jenkins-firstcorpus_reader",
        "jenkins-firstcorpus_commenter"
      ],
      "before": [],
      "after": [
        "writer",
        "reader",
        "commenter"
      ],
      "status": 200,
      "message": "User testingspreadsheet now has writer reader commenter access to jenkins-firstcorpus"
    }
  ],
  "info": [
    "User testingspreadsheet now has writer reader commenter access to jenkins-firstcorpus"
  ]
}
   success
        "jenkins-firstcorpus_commenter"
      ],
      "before": [],
      "after": [
        "writer",
        "reader",
        "commenter"
    server replied with informative info
-------------------------------------------------------------
It should accept new updateroles (from the spreadsheet app)
     {
      "username": "jenkins",
      "password": "phoneme",
      "serverCode": "localhost",
      "pouchname": "jenkins-firstcorpus",
      "users": [{
        "username": "testingspreadsheet",
        "add": ["writer", "commenter", "reader"],
        "remove": ["admin"]
      }]
     }
 prep: remove the user


Response: {
  "users": [
    {
      "username": "testingspreadsheet",
      "add": [
        "jenkins-firstcorpus_writer",
        "jenkins-firstcorpus_commenter",
        "jenkins-firstcorpus_reader"
      ],
      "remove": [
        "jenkins-firstcorpus_admin"
      ],
      "before": [],
      "after": [
        "writer",
        "commenter",
        "reader"
      ],
      "status": 200,
      "message": "User testingspreadsheet now has writer commenter reader access to jenkins-firstcorpus"
    }
  ],
  "info": [
    "User testingspreadsheet now has writer commenter reader access to jenkins-firstcorpus"
  ]
}
   success
        "jenkins-firstcorpus_admin"
      ],
      "before": [],
      "after": [
        "writer",
        "commenter",
        "reader"
    server replied with informative info


=============================================================
Test results for deprecated routes
27 passed of 27
Ran 27 of 27 expected
=============================================================

Done, without errors.

```